### PR TITLE
fix: avoid livewire race condition in business-hour calendar modal

### DIFF
--- a/src/resources/views/filament/resources/business-hour-resource/pages/manage-business-hour-calendar.blade.php
+++ b/src/resources/views/filament/resources/business-hour-resource/pages/manage-business-hour-calendar.blade.php
@@ -39,7 +39,7 @@
                     <input
                         type="radio"
                         value="1"
-                        wire:model.live="monthPublication"
+                        wire:model="monthPublication"
                         class="h-4 w-4 border-emerald-300 text-emerald-600 focus:ring-emerald-500"
                     >
                     公開
@@ -49,7 +49,7 @@
                     <input
                         type="radio"
                         value="0"
-                        wire:model.live="monthPublication"
+                        wire:model="monthPublication"
                         class="h-4 w-4 border-rose-300 text-rose-600 focus:ring-rose-500"
                     >
                     非公開
@@ -114,7 +114,7 @@
             <label class="flex items-center gap-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-semibold text-rose-700">
                 <input
                     type="checkbox"
-                    wire:model.live="calendarModalIsClosed"
+                    wire:model="calendarModalIsClosed"
                     class="h-4 w-4 rounded border-rose-300 text-rose-600 focus:ring-rose-500"
                 >
                 この日を休業日にする
@@ -125,7 +125,7 @@
                     <span class="mb-1 block font-semibold text-slate-700">開始時刻</span>
                     <input
                         type="time"
-                        wire:model.live="calendarModalOpenTime"
+                        wire:model="calendarModalOpenTime"
                         step="300"
                         @disabled($this->calendarModalIsClosed)
                         class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-sky-400 focus:outline-none focus:ring-1 focus:ring-sky-400 disabled:bg-slate-100 disabled:text-slate-400"
@@ -136,7 +136,7 @@
                     <span class="mb-1 block font-semibold text-slate-700">終了時刻</span>
                     <input
                         type="time"
-                        wire:model.live="calendarModalCloseTime"
+                        wire:model="calendarModalCloseTime"
                         step="300"
                         @disabled($this->calendarModalIsClosed)
                         class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-sky-400 focus:outline-none focus:ring-1 focus:ring-sky-400 disabled:bg-slate-100 disabled:text-slate-400"


### PR DESCRIPTION
This pull request updates several input bindings in the `manage-business-hour-calendar.blade.php` view to improve Livewire integration. The main change is replacing the deprecated or unnecessary `.live` modifier from the `wire:model.live` directive with the standard `wire:model` directive for all relevant form inputs.

**Livewire directive updates:**

* Replaced `wire:model.live` with `wire:model` for the `monthPublication` radio inputs, ensuring proper two-way data binding without the `.live` modifier. [[1]](diffhunk://#diff-aae2e5a5cf90572c75546a19df5418823e64e78cf2c32dfa86c23db76246a9c0L42-R42) [[2]](diffhunk://#diff-aae2e5a5cf90572c75546a19df5418823e64e78cf2c32dfa86c23db76246a9c0L52-R52)
* Updated the checkbox for `calendarModalIsClosed` to use `wire:model` instead of `wire:model.live`.
* Changed the time inputs for `calendarModalOpenTime` and `calendarModalCloseTime` to use `wire:model` instead of `wire:model.live`. [[1]](diffhunk://#diff-aae2e5a5cf90572c75546a19df5418823e64e78cf2c32dfa86c23db76246a9c0L128-R128) [[2]](diffhunk://#diff-aae2e5a5cf90572c75546a19df5418823e64e78cf2c32dfa86c23db76246a9c0L139-R139)