### PR TITLE
fix: use whereDate for specific_date lookup to handle UTC timestamp s…

### DIFF
--- a/src/app/Models/BusinessHour.php
+++ b/src/app/Models/BusinessHour.php
@@ -32,7 +32,7 @@ class BusinessHour extends Model
      */
     public static function getSettingForDate(Carbon $date): ?self
     {
-        $specific = self::where('specific_date', $date->toDateString())
+        $specific = self::whereDate('specific_date', $date->toDateString())
             ->first();
 
         if ($specific) {


### PR DESCRIPTION
This pull request makes a minor adjustment to how the `BusinessHour` model queries records for a specific date. The change ensures that date comparisons are handled correctly by using the `whereDate` method instead of `where` when filtering by `specific_date`. 

- Improved date filtering by replacing `where` with `whereDate` in the `getSettingForDate` method of the `BusinessHour` model to ensure accurate date-based queries.This pull request makes a minor update to the `BusinessHour` model to improve date-based querying. The change uses the `whereDate` method instead of `where` for comparing the `specific_date` field, ensuring more accurate and consistent date filtering.…torage