### PR TITLE
Fix system setting singleton linkage for dashboard and notifications

### DIFF
--- a/src/app/Filament/Resources/SystemSettingResource/Pages/EditSystemSetting.php
+++ b/src/app/Filament/Resources/SystemSettingResource/Pages/EditSystemSetting.php
@@ -12,10 +12,9 @@ class EditSystemSetting extends EditRecord
 
     public function mount(int|string|null $record = null): void
     {
-        $this->record = SystemSetting::getSingleton();
+        $singleton = SystemSetting::getSingleton();
 
-        $this->authorizeAccess();
-        $this->fillForm();
+        parent::mount((string) $singleton->getKey());
         $this->previousUrl = url()->previous();
     }
 

--- a/src/app/Filament/Widgets/SystemSettingsAlert.php
+++ b/src/app/Filament/Widgets/SystemSettingsAlert.php
@@ -12,9 +12,9 @@ class SystemSettingsAlert extends Widget
 
     protected int|string|array $columnSpan = 'full';
 
-    public function shouldRender(): bool
+    public static function canView(): bool
     {
-        $settings = SystemSetting::first();
+        $settings = SystemSetting::getSingleton();
 
         return ! ($settings && $settings->hasAdminNotificationSettings());
     }

--- a/src/app/Models/SystemSetting.php
+++ b/src/app/Models/SystemSetting.php
@@ -36,7 +36,25 @@ class SystemSetting extends Model
 
     public static function getSingleton(): self
     {
-        return static::firstOrCreate([]);
+        $singleton = static::query()->find(1);
+
+        if ($singleton) {
+            return $singleton;
+        }
+
+        $legacy = static::query()->orderBy('id')->first();
+
+        if ($legacy) {
+            if ($legacy->id !== 1) {
+                static::query()->whereKey($legacy->id)->update(['id' => 1]);
+
+                return static::query()->findOrFail(1);
+            }
+
+            return $legacy;
+        }
+
+        return static::query()->forceCreate(['id' => 1]);
     }
 
     public function hasNotificationFrom(): bool

--- a/src/app/Services/NotificationService.php
+++ b/src/app/Services/NotificationService.php
@@ -19,7 +19,7 @@ class NotificationService
     public function sendReservationConfirmedToUser(Reservation $reservation): void
     {
         try {
-            $settings = SystemSetting::first();
+            $settings = SystemSetting::getSingleton();
             $this->applyFromSettings($settings);
 
             Mail::to($reservation->user->email)
@@ -38,7 +38,7 @@ class NotificationService
     public function sendReservationCanceledToUser(Reservation $reservation): void
     {
         try {
-            $settings = SystemSetting::first();
+            $settings = SystemSetting::getSingleton();
             $this->applyFromSettings($settings);
 
             Mail::to($reservation->user->email)
@@ -57,7 +57,7 @@ class NotificationService
     public function sendAdminNotification(Reservation $reservation, string $type): void
     {
         try {
-            $settings = SystemSetting::first();
+            $settings = SystemSetting::getSingleton();
 
             if (! $this->isAdminNotificationConfigured($settings)) {
                 Log::warning('管理者通知設定が未設定のため送信をスキップしました', [

--- a/src/database/migrations/2026_04_20_000300_normalize_system_settings_singleton.php
+++ b/src/database/migrations/2026_04_20_000300_normalize_system_settings_singleton.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('system_settings')) {
+            return;
+        }
+
+        $canonical = DB::table('system_settings')
+            ->orderByDesc('updated_at')
+            ->orderByDesc('id')
+            ->first();
+
+        if (! $canonical) {
+            DB::table('system_settings')->insert([
+                'id' => 1,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            return;
+        }
+
+        $payload = (array) $canonical;
+        unset($payload['id']);
+        $payload['updated_at'] = now();
+
+        if (! array_key_exists('created_at', $payload) || empty($payload['created_at'])) {
+            $payload['created_at'] = now();
+        }
+
+        if (DB::table('system_settings')->where('id', 1)->exists()) {
+            DB::table('system_settings')->where('id', 1)->update($payload);
+        } else {
+            DB::table('system_settings')->insert(array_merge(['id' => 1], $payload));
+        }
+
+        DB::table('system_settings')->where('id', '!=', 1)->delete();
+    }
+
+    public function down(): void
+    {
+        // No-op: cannot safely restore deleted duplicate rows.
+    }
+};

--- a/src/database/seeders/SystemSettingSeeder.php
+++ b/src/database/seeders/SystemSettingSeeder.php
@@ -12,6 +12,6 @@ class SystemSettingSeeder extends Seeder
      */
     public function run(): void
     {
-        SystemSetting::firstOrCreate([]);
+        SystemSetting::getSingleton();
     }
 }


### PR DESCRIPTION
This pull request standardizes the handling of the `SystemSetting` model as a true singleton throughout the codebase. It introduces a robust method for retrieving or creating the singleton record, updates all usages to rely on this method, and adds a migration to ensure only a single canonical settings row exists in the database.

**Singleton enforcement and usage:**

* Added a new implementation of `SystemSetting::getSingleton()` to always return the record with `id = 1`, migrate legacy records, and create the singleton if needed. This ensures a single, canonical settings record.
* Updated all usages of `SystemSetting::first()` and `SystemSetting::firstOrCreate([])` to use `SystemSetting::getSingleton()` in the application logic and seeders, ensuring consistent singleton access. [[1]](diffhunk://#diff-70c6ce905e238d98c838ef00e30a31a15784c58ab0c97fbddd85032f0876bf5fL22-R22) [[2]](diffhunk://#diff-70c6ce905e238d98c838ef00e30a31a15784c58ab0c97fbddd85032f0876bf5fL41-R41) [[3]](diffhunk://#diff-70c6ce905e238d98c838ef00e30a31a15784c58ab0c97fbddd85032f0876bf5fL60-R60) [[4]](diffhunk://#diff-ebce899af6ff3d90473da993a446b9930efa80b5408bd71aa2b26ed5ca3546c5L15-R15) [[5]](diffhunk://#diff-de171a43ce007ca706209b03d6df7e19346485ef7606857b83ae2c3ce5300dc7L15-R17) [[6]](diffhunk://#diff-f2137f1f9d6ec5a4184c99dd33b4d841eb56b726a89919beb98511633bef57acL15-R17)

**Database migration:**

* Added a migration (`2026_04_20_000300_normalize_system_settings_singleton.php`) that consolidates any existing `system_settings` rows into a single canonical record with `id = 1`, copying the latest data and removing duplicates.

**Other adjustments:**

* Updated the `EditSystemSetting` page to mount using the singleton's key, ensuring the correct record is always loaded for editing.
* Changed `SystemSettingsAlert` to use the new singleton accessor and updated the method name for clarity and consistency.