### PR TITLE
タイトル修正、２重クリック防止、ダッシュボード修正

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -1,4 +1,4 @@
-APP_NAME="Sorairo Note 2"
+APP_NAME="Sorairo Note"
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true

--- a/src/app/Providers/Filament/AdminPanelProvider.php
+++ b/src/app/Providers/Filament/AdminPanelProvider.php
@@ -29,6 +29,7 @@ class AdminPanelProvider extends PanelProvider
             ->default()
             ->id('admin')
             ->path('admin')
+            ->brandName('Sorairo Note')
             ->login()
             ->colors([
                 'primary' => Color::Amber,

--- a/src/resources/views/dashboard.blade.php
+++ b/src/resources/views/dashboard.blade.php
@@ -10,63 +10,43 @@
     </x-slot>
 
     <div class="py-8">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid gap-6 lg:grid-cols-3">
-                <div class="lg:col-span-2 space-y-4">
-                    @forelse($notes as $note)
-                        <div class="relative overflow-hidden rounded-2xl shadow-lg border border-sky-100 bg-gradient-to-br from-sky-50 via-white to-blue-50">
-                            <div class="absolute -right-10 -top-10 w-40 h-40 bg-sky-200/40 blur-3xl"></div>
-                            <div class="absolute -left-6 -bottom-12 w-48 h-48 bg-blue-200/30 blur-3xl"></div>
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="space-y-4">
+                @forelse($notes as $note)
+                    <div class="relative overflow-hidden rounded-2xl shadow-lg border border-sky-100 bg-gradient-to-br from-sky-50 via-white to-blue-50">
+                        <div class="absolute -right-10 -top-10 w-40 h-40 bg-sky-200/40 blur-3xl"></div>
+                        <div class="absolute -left-6 -bottom-12 w-48 h-48 bg-blue-200/30 blur-3xl"></div>
 
-                            <div class="p-5 sm:p-6 flex flex-col gap-4 relative">
-                                <div class="flex items-start justify-between gap-3">
-                                    <div>
-                                        <p class="text-xs text-sky-600 font-semibold">
-                                            {{ optional($note->published_at ?? $note->created_at)->format('Y/m/d H:i') }}
-                                        </p>
-                                        <h3 class="text-xl font-bold text-sky-900">{{ $note->title }}</h3>
+                        <div class="p-5 sm:p-6 flex flex-col gap-4 relative">
+                            <div class="flex items-start justify-between gap-3">
+                                <div>
+                                    <p class="text-xs text-sky-600 font-semibold">
+                                        {{ optional($note->published_at ?? $note->created_at)->format('Y/m/d H:i') }}
+                                    </p>
+                                    <h3 class="text-xl font-bold text-sky-900">{{ $note->title }}</h3>
+                                </div>
+                                @if($note->image_path)
+                                    <div class="w-24 h-24 rounded-xl overflow-hidden shadow-md ring-1 ring-sky-100">
+                                        <img src="{{ asset('storage/'.$note->image_path) }}" alt="{{ $note->title }}" class="w-full h-full object-cover">
                                     </div>
-                                    @if($note->image_path)
-                                        <div class="w-24 h-24 rounded-xl overflow-hidden shadow-md ring-1 ring-sky-100">
-                                            <img src="{{ asset('storage/'.$note->image_path) }}" alt="{{ $note->title }}" class="w-full h-full object-cover">
-                                        </div>
-                                    @endif
-                                </div>
+                                @endif
+                            </div>
 
-                                <p class="text-sky-900/80 leading-relaxed text-sm sm:text-base whitespace-pre-line">{{ $note->content }}</p>
+                            <p class="text-sky-900/80 leading-relaxed text-sm sm:text-base whitespace-pre-line">{{ $note->content }}</p>
 
-                                <div class="flex items-center gap-3 text-xs text-sky-700">
-                                    <span class="inline-flex items-center px-3 py-1 rounded-full bg-white/80 border border-sky-100 shadow-sm">
-                                        <svg class="w-4 h-4 mr-1 text-sky-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                                        最新情報
-                                    </span>
-                                </div>
+                            <div class="flex items-center gap-3 text-xs text-sky-700">
+                                <span class="inline-flex items-center px-3 py-1 rounded-full bg-white/80 border border-sky-100 shadow-sm">
+                                    <svg class="w-4 h-4 mr-1 text-sky-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                    最新情報
+                                </span>
                             </div>
                         </div>
-                    @empty
-                        <div class="rounded-2xl border border-sky-100 bg-gradient-to-br from-sky-50 to-white p-8 text-center text-sky-700 shadow-inner">
-                            まだお知らせはありません。
-                        </div>
-                    @endforelse
-                </div>
-
-                <div class="space-y-4">
-                    <div class="rounded-2xl bg-gradient-to-br from-sky-500 to-blue-600 text-white shadow-xl p-6 relative overflow-hidden">
-                        <div class="absolute inset-0 bg-white/10 mix-blend-overlay"></div>
-                        <h3 class="text-xl font-bold">ようこそ</h3>
-                        <p class="mt-2 text-sm text-white/90">最新のお知らせを確認してください</p>
-                        <div class="mt-4 text-3xl font-black drop-shadow">Sorairo</div>
                     </div>
-
-                    <div class="rounded-2xl border border-sky-100 bg-white shadow-sm p-5">
-                        <h4 class="text-sm font-semibold text-sky-800 mb-2">ヘルプ</h4>
-                        <ul class="space-y-1 text-sm text-sky-900/80 list-disc list-inside">
-                            <li>メニューから予約を作成</li>
-                            <li>マイページで予約の確認・キャンセル</li>
-                            <li>お知らせで最新情報をチェック</li>
-                        </ul>
+                @empty
+                    <div class="rounded-2xl border border-sky-100 bg-gradient-to-br from-sky-50 to-white p-8 text-center text-sky-700 shadow-inner">
+                        まだお知らせはありません。
                     </div>
-                </div>
+                @endforelse
             </div>
         </div>
     </div>

--- a/src/resources/views/layouts/navigation.blade.php
+++ b/src/resources/views/layouts/navigation.blade.php
@@ -85,6 +85,29 @@
                 </button>
             </div>
         </div>
+
+        <div class="grid grid-cols-2 gap-2 pb-2 sm:hidden">
+            <a href="{{ route('menus.index') }}"
+               class="inline-flex items-center justify-center rounded-lg px-3 py-2 text-[13px] font-semibold shadow-sm
+                      transition-all duration-150 ease-out
+                      active:scale-95 active:brightness-90
+                      {{ request()->routeIs('menus.*')
+                          ? 'bg-sky-600 text-white shadow-sky-300 shadow-md'
+                          : 'bg-white/80 text-sky-800 ring-1 ring-sky-200' }}"
+               aria-label="メニュー">
+                メニュー
+            </a>
+            <a href="{{ route('mypage') }}"
+               class="inline-flex items-center justify-center rounded-lg px-3 py-2 text-[13px] font-semibold shadow-sm
+                      transition-all duration-150 ease-out
+                      active:scale-95 active:brightness-90
+                      {{ request()->routeIs('mypage')
+                          ? 'bg-sky-600 text-white shadow-sky-300 shadow-md'
+                          : 'bg-white/80 text-sky-800 ring-1 ring-sky-200' }}"
+               aria-label="マイページ">
+                マイページ
+            </a>
+        </div>
     </div>
 
     <!-- Responsive Navigation Menu -->
@@ -92,14 +115,6 @@
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('お知らせ') }}
-            </x-responsive-nav-link>
-
-            <x-responsive-nav-link :href="route('menus.index')" :active="request()->routeIs('menus.*')">
-                メニュー
-            </x-responsive-nav-link>
-
-            <x-responsive-nav-link :href="route('mypage')" :active="request()->routeIs('mypage')">
-                マイページ
             </x-responsive-nav-link>
             
             @if(auth()->check() && auth()->user()->is_admin)

--- a/src/resources/views/reservations/confirm.blade.php
+++ b/src/resources/views/reservations/confirm.blade.php
@@ -72,7 +72,10 @@
                 </div>
 
                 <!-- 予約ボタン -->
-                <form method="POST" action="{{ route('reservations.store') }}">
+                <form method="POST"
+                        action="{{ route('reservations.store') }}"
+                        x-data="{ submitting: false }"
+                        @submit="if (submitting) { $event.preventDefault(); return; } submitting = true">
                     @csrf
                     <input type="hidden" name="menu_id" value="{{ $menu->id }}">
                     <input type="hidden" name="date" value="{{ $date }}">
@@ -83,10 +86,14 @@
 
                     <div class="flex gap-4">
                         <button type="submit"
-                                class="flex-1 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition font-semibold text-center">
-                            予約を確定する
+                                :disabled="submitting"
+                                :class="submitting ? 'bg-blue-500 cursor-not-allowed opacity-70' : 'bg-blue-600 hover:bg-blue-700'"
+                                class="flex-1 px-6 py-3 text-white rounded-lg transition font-semibold text-center">
+                            <span x-show="!submitting">予約を確定する</span>
+                            <span x-show="submitting" x-cloak>確定中...</span>
                         </button>
                         <a href="{{ route('reservations.calendar', ['menu_id' => $menu->id]) }}"
+                           :class="submitting ? 'pointer-events-none opacity-50' : ''"
                            class="px-6 py-3 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition font-semibold">
                             戻る
                         </a>

--- a/src/tests/Feature/DashboardTest.php
+++ b/src/tests/Feature/DashboardTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Note;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dashboard_prioritizes_news_and_keeps_primary_links_visible(): void
+    {
+        $user = User::factory()->create();
+
+        Note::create([
+            'title' => '営業日のお知らせ',
+            'content' => '今週の営業スケジュールを更新しました。',
+            'is_published' => true,
+            'published_at' => now(),
+        ]);
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertOk();
+        $response->assertSee('Sorairo News');
+        $response->assertSee('営業日のお知らせ');
+        $response->assertDontSee('ようこそ');
+        $response->assertDontSee('ヘルプ');
+        $response->assertSee('メニュー');
+        $response->assertSee('マイページ');
+    }
+}


### PR DESCRIPTION
This pull request focuses on refining the user interface and experience for the dashboard and navigation, as well as improving the reservation confirmation process. It also introduces a new feature test to ensure the dashboard prioritizes news and maintains visibility of key navigation links. The most important changes are grouped below:

**Dashboard and Navigation UI Improvements:**

* Simplified the dashboard layout by reducing the maximum width, removing the sidebar with welcome/help sections, and focusing on displaying notes/news more prominently in `dashboard.blade.php`. [[1]](diffhunk://#diff-78fe63de0749f072fd4cb453d8cc32c7bc218ad04bed0b11ceb0a32cde911409L13-R14) [[2]](diffhunk://#diff-78fe63de0749f072fd4cb453d8cc32c7bc218ad04bed0b11ceb0a32cde911409L52-L70)
* Updated the responsive navigation for mobile devices by adding prominent "メニュー" and "マイページ" buttons and removing their previous entries from the mobile navigation links in `navigation.blade.php`. [[1]](diffhunk://#diff-e5e1e5e42fecc4ac6302da87724d37a7c9330d33ad2878c954f305bb771b06d0R88-R110) [[2]](diffhunk://#diff-e5e1e5e42fecc4ac6302da87724d37a7c9330d33ad2878c954f305bb771b06d0L97-L104)
* Changed the application name from "Sorairo Note 2" to "Sorairo Note" in `.env.example` and set the brand name for the admin panel in `AdminPanelProvider.php`. [[1]](diffhunk://#diff-37d244a68001b3a8ce7d98f05894470bb8e6fb387402adc29351d41570e3e1e6L1-R1) [[2]](diffhunk://#diff-031d4a5fe5c832c0b9f4b649b63277e1c073980dd2b0c00bd4531ce3b36afffcR32)

**Reservation Confirmation UX Enhancement:**

* Improved the reservation confirmation form to prevent double submission by disabling the submit button and showing a loading state while submitting, and also disabling the back link during submission in `confirm.blade.php`. [[1]](diffhunk://#diff-da4d7e7f3d91787ba183abf13623f821f7af75f9861f409611fd8307718575b4L75-R78) [[2]](diffhunk://#diff-da4d7e7f3d91787ba183abf13623f821f7af75f9861f409611fd8307718575b4L86-R96)

**Testing:**

* Added a feature test (`DashboardTest`) to verify that the dashboard prioritizes displaying news, hides the removed welcome/help sections, and ensures that "メニュー" and "マイページ" links remain visible.