### PR TITLE
CIエラー:Deploy to Render

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,8 @@ jobs:
           response=$(curl -s -o /dev/null -w "%{http_code}" "${{ secrets.RENDER_DEPLOY_HOOK_URL }}")
           if [ "$response" -eq 200 ] || [ "$response" -eq 201 ]; then
             echo "✅ Deploy triggered successfully (HTTP $response)"
+          elif [ "$response" -eq 409 ]; then
+            echo "ℹ️ Deploy already in progress on Render (HTTP $response), continuing"
           else
             echo "::error::Deploy hook failed with HTTP $response"
             exit 1


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow to better handle situations where a deployment is already in progress on Render. Now, if the deploy hook returns a 409 status code, the workflow logs an informational message and continues instead of failing.

- Deployment workflow improvement:
  * Updated the deploy script in `.github/workflows/deploy.yml` to handle HTTP 409 responses from Render by logging an informational message and continuing, instead of treating it as an error.