### PR TITLE
ウェルカムページ設定の修正２回目

### DIFF
--- a/src/app/Filament/Resources/WelcomePageSettingResource.php
+++ b/src/app/Filament/Resources/WelcomePageSettingResource.php
@@ -66,7 +66,7 @@ class WelcomePageSettingResource extends Resource
         return [
             Forms\Components\Placeholder::make('welcome_mapping_guide')
                 ->label('設定項目と反映箇所')
-                ->content(new HtmlString('① ヒーロー: バッジ/見出し/リード文/メイン画像<br>② 本文セクション: 「本文セクション（文章・画像）」の各ブロック<br>③ 店舗情報カード: タイトル/紹介文/営業時間/補足<br>④ 全体デザイン: 背景テーマ・アクセントカラー'))
+                ->content(new HtmlString('① ヒーロー: バッジ/見出し/リード文/メイン画像<br>② 本文セクション: 「本文セクション（文章・画像）」の各ブロック<br>③ 店舗情報カード: タイトル/紹介文/営業時間/補足<br>④ 全体デザイン: 背景テーマ・アクセントカラー<br>⑤ レイアウト: カード余白/角丸/影/フォント'))
                 ->columnSpanFull(),
             Forms\Components\TextInput::make('welcome_badge')
                 ->label('バッジテキスト')
@@ -346,6 +346,41 @@ class WelcomePageSettingResource extends Resource
                 ->helperText('ヘッダーのInstagramボタンに反映されます。http:// または https:// で始まるURLを入力してください。')
                 ->columnSpanFull()
                 ->live(onBlur: true),
+            Forms\Components\Select::make('welcome_card_padding')
+                ->label('カード余白密度')
+                ->options([
+                    'compact' => 'コンパクト（狭め）',
+                    'normal' => '標準（推奨）',
+                    'spacious' => 'ゆったり（広め）',
+                ])
+                ->helperText('ヒーロー・お店のご案内・店舗情報カードの内側余白に反映されます。')
+                ->native(false),
+            Forms\Components\Select::make('welcome_card_radius')
+                ->label('カード角丸')
+                ->options([
+                    'none' => '小（やや角あり）',
+                    'rounded' => '中（丸め）',
+                    'rounder' => '大（推奨）',
+                ])
+                ->helperText('各カードの角の丸さに反映されます。')
+                ->native(false),
+            Forms\Components\Select::make('welcome_card_shadow')
+                ->label('カードの影')
+                ->options([
+                    'none' => 'なし',
+                    'soft' => '控えめ',
+                    'strong' => '標準（推奨）',
+                ])
+                ->helperText('各カードに付く影の強さに反映されます。')
+                ->native(false),
+            Forms\Components\Select::make('welcome_font_style')
+                ->label('フォント種別')
+                ->options([
+                    'sans' => 'サンセリフ（推奨）',
+                    'serif' => 'セリフ体',
+                ])
+                ->helperText('ページ全体のフォント種別に反映されます。')
+                ->native(false),
         ];
     }
 
@@ -393,6 +428,10 @@ class WelcomePageSettingResource extends Resource
             'shop_body_size' => $state['welcome_shop_body_size'] ?? null,
             'shop_body_color' => $state['welcome_shop_body_color'] ?? null,
             'shop_paragraph_mode' => $state['welcome_shop_paragraph_mode'] ?? null,
+            'card_padding' => $state['welcome_card_padding'] ?? null,
+            'card_radius' => $state['welcome_card_radius'] ?? null,
+            'card_shadow' => $state['welcome_card_shadow'] ?? null,
+            'font_style' => $state['welcome_font_style'] ?? null,
         ];
     }
 

--- a/src/app/Models/SystemSetting.php
+++ b/src/app/Models/SystemSetting.php
@@ -59,6 +59,10 @@ class SystemSetting extends Model
         'welcome_shop_body_size',
         'welcome_shop_body_color',
         'welcome_shop_paragraph_mode',
+        'welcome_card_padding',
+        'welcome_card_radius',
+        'welcome_card_shadow',
+        'welcome_font_style',
     ];
 
     protected $casts = [

--- a/src/app/Support/WelcomeStyleHelper.php
+++ b/src/app/Support/WelcomeStyleHelper.php
@@ -205,4 +205,57 @@ class WelcomeStyleHelper
 
         return implode(' ', ! empty($desktop) ? $desktop : $base);
     }
+
+    public static function cardPaddingHeroClass(?string $value): string
+    {
+        return [
+            'compact' => 'p-5 lg:p-8',
+            'normal' => 'p-8 lg:p-12',
+            'spacious' => 'p-10 lg:p-16',
+        ][$value ?? ''] ?? 'p-8 lg:p-12';
+    }
+
+    public static function cardPaddingShopClass(?string $value): string
+    {
+        return [
+            'compact' => 'p-4 lg:p-5',
+            'normal' => 'p-6 lg:p-8',
+            'spacious' => 'p-8 lg:p-10',
+        ][$value ?? ''] ?? 'p-6 lg:p-8';
+    }
+
+    public static function cardPaddingBlockClass(?string $value): string
+    {
+        return [
+            'compact' => 'p-3',
+            'normal' => 'p-5',
+            'spacious' => 'p-7',
+        ][$value ?? ''] ?? 'p-5';
+    }
+
+    public static function cardRadiusClass(?string $value): string
+    {
+        return [
+            'none' => 'rounded-lg',
+            'rounded' => 'rounded-2xl',
+            'rounder' => 'rounded-3xl',
+        ][$value ?? ''] ?? 'rounded-3xl';
+    }
+
+    public static function cardShadowClass(?string $value): string
+    {
+        return [
+            'none' => 'shadow-none',
+            'soft' => 'shadow-md',
+            'strong' => 'shadow-xl',
+        ][$value ?? ''] ?? 'shadow-xl';
+    }
+
+    public static function fontStyleClass(?string $value): string
+    {
+        return [
+            'sans' => 'font-sans',
+            'serif' => 'font-serif',
+        ][$value ?? ''] ?? 'font-sans';
+    }
 }

--- a/src/database/migrations/2026_05_18_210000_add_welcome_layout_fields_to_system_settings_table.php
+++ b/src/database/migrations/2026_05_18_210000_add_welcome_layout_fields_to_system_settings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('system_settings', function (Blueprint $table) {
+            $table->string('welcome_card_padding')->nullable()->after('welcome_shop_paragraph_mode');
+            $table->string('welcome_card_radius')->nullable()->after('welcome_card_padding');
+            $table->string('welcome_card_shadow')->nullable()->after('welcome_card_radius');
+            $table->string('welcome_font_style')->nullable()->after('welcome_card_shadow');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('system_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'welcome_card_padding',
+                'welcome_card_radius',
+                'welcome_card_shadow',
+                'welcome_font_style',
+            ]);
+        });
+    }
+};

--- a/src/database/seeders/DatabaseSeeder.php
+++ b/src/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,12 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        if (app()->environment('production')) {
+            $this->command->warn('DatabaseSeeder は本番環境では実行されません。スキップします。');
+
+            return;
+        }
+
         $this->call(SystemSettingSeeder::class);
 
         User::updateOrCreate(

--- a/src/resources/views/filament/resources/welcome-page-setting-resource/partials/welcome-preview.blade.php
+++ b/src/resources/views/filament/resources/welcome-page-setting-resource/partials/welcome-preview.blade.php
@@ -15,6 +15,16 @@
         $shopTitleColorClass = \App\Support\WelcomeStyleHelper::shopTitleColorClass($shop_title_color ?? null);
         $shopBodySizeClass = \App\Support\WelcomeStyleHelper::shopBodySizeClass($shop_body_size ?? null);
         $shopBodyColorClass = \App\Support\WelcomeStyleHelper::shopBodyColorClass($shop_body_color ?? null);
+        $cardPaddingHeroClass = \App\Support\WelcomeStyleHelper::cardPaddingHeroClass($card_padding ?? null);
+        $cardPaddingShopClass = \App\Support\WelcomeStyleHelper::cardPaddingShopClass($card_padding ?? null);
+        $cardPaddingBlockClass = \App\Support\WelcomeStyleHelper::cardPaddingBlockClass($card_padding ?? null);
+        $cardRadiusClass = \App\Support\WelcomeStyleHelper::cardRadiusClass($card_radius ?? null);
+        $cardShadowClass = \App\Support\WelcomeStyleHelper::cardShadowClass($card_shadow ?? null);
+        $fontStyleClass = \App\Support\WelcomeStyleHelper::fontStyleClass($font_style ?? null);
+        $cardPaddingHeroMobileClass = \App\Support\WelcomeStyleHelper::previewResponsiveClass($cardPaddingHeroClass, 'mobile');
+        $cardPaddingHeroDesktopClass = \App\Support\WelcomeStyleHelper::previewResponsiveClass($cardPaddingHeroClass, 'desktop');
+        $cardPaddingShopMobileClass = \App\Support\WelcomeStyleHelper::previewResponsiveClass($cardPaddingShopClass, 'mobile');
+        $cardPaddingShopDesktopClass = \App\Support\WelcomeStyleHelper::previewResponsiveClass($cardPaddingShopClass, 'desktop');
 
         $heroTitleSizeMobileClass = \App\Support\WelcomeStyleHelper::previewResponsiveClass($heroTitleSizeClass, 'mobile');
         $heroTitleSizeDesktopClass = \App\Support\WelcomeStyleHelper::previewResponsiveClass($heroTitleSizeClass, 'desktop');
@@ -54,8 +64,11 @@
         <button type="button" @click="viewport = 'desktop'" :class="viewport === 'desktop' ? 'bg-slate-900 text-white' : 'bg-white text-slate-700 border border-slate-200'" class="rounded-full px-3 py-1 text-xs font-semibold">Desktop</button>
     </div>
 
-    <div class="mx-auto space-y-4 rounded-lg {{ $themeBackgroundClass }} p-6 transition-all duration-200" :class="viewport === 'mobile' ? 'max-w-[340px]' : (viewport === 'tablet' ? 'max-w-3xl' : 'max-w-5xl')">
-        <div class="rounded-2xl bg-white/70 p-6 backdrop-blur-lg">
+    <div class="mx-auto space-y-4 rounded-lg {{ $themeBackgroundClass }} {{ $fontStyleClass }} p-6 transition-all duration-200" :class="viewport === 'mobile' ? 'max-w-[340px]' : (viewport === 'tablet' ? 'max-w-3xl' : 'max-w-5xl')">
+        <div
+            :class="viewport === 'mobile' ? '{{ $cardPaddingHeroMobileClass }}' : '{{ $cardPaddingHeroDesktopClass }}'"
+            class="{{ $cardRadiusClass }} bg-white/70 backdrop-blur-lg {{ $cardShadowClass }}"
+        >
             <div class="space-y-3 {{ $heroAlignClass }}">
                 @if ($hero_badge ?? null)
                     <span class="inline-block rounded-full px-3 py-1 text-sm font-semibold {{ $accentClasses['badge'] }}">
@@ -99,7 +112,7 @@
                 <h2 class="font-semibold text-slate-900">本文セクション</h2>
                 @if ($previewBlockCount === 1)
                     @foreach ($body_blocks as $index => $block)
-                        <div class="rounded-xl border border-white/60 bg-white/80 p-4 shadow-sm">
+                        <div class="{{ $cardRadiusClass }} border border-white/60 bg-white/80 {{ $cardPaddingBlockClass }} {{ $cardShadowClass }}">
                             <div class="flex items-start gap-2">
                                 <span class="mt-1 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-sky-500 text-sm font-bold text-white">1</span>
                                 <div class="flex-1">
@@ -155,7 +168,7 @@
                                 x-show="current === {{ $index }}"
                                 x-transition:enter.duration.350ms
                                 :class="direction === 'right' ? 'slide-enter-right' : 'slide-enter-left'"
-                                class="rounded-xl border border-white/60 bg-white/80 p-4 shadow-sm"
+                                class="{{ $cardRadiusClass }} border border-white/60 bg-white/80 {{ $cardPaddingBlockClass }} {{ $cardShadowClass }}"
                                 @if ($index !== 0) style="display:none;" @endif
                             >
                                 <div class="flex items-start gap-2">
@@ -212,7 +225,10 @@
             </div>
         @endif
 
-        <div class="rounded-2xl border border-white/50 bg-gradient-to-br from-sky-200/70 via-white to-cyan-200/70 p-6 backdrop-blur-lg">
+        <div
+            :class="viewport === 'mobile' ? '{{ $cardPaddingShopMobileClass }}' : '{{ $cardPaddingShopDesktopClass }}'"
+            class="{{ $cardRadiusClass }} border border-white/50 bg-gradient-to-br from-sky-200/70 via-white to-cyan-200/70 backdrop-blur-lg {{ $cardShadowClass }}"
+        >
             <h3 class="mb-3 font-bold {{ $shopTitleSizeClass }} {{ $shopTitleColorClass }}">
                 {{ $shop_title ?? '店舗情報' }}
             </h3>

--- a/src/resources/views/welcome.blade.php
+++ b/src/resources/views/welcome.blade.php
@@ -28,6 +28,12 @@
         $shopTitleColorClass = \App\Support\WelcomeStyleHelper::shopTitleColorClass($settings->welcome_shop_title_color);
         $shopBodySizeClass = \App\Support\WelcomeStyleHelper::shopBodySizeClass($settings->welcome_shop_body_size);
         $shopBodyColorClass = \App\Support\WelcomeStyleHelper::shopBodyColorClass($settings->welcome_shop_body_color);
+        $cardPaddingHeroClass = \App\Support\WelcomeStyleHelper::cardPaddingHeroClass($settings->welcome_card_padding);
+        $cardPaddingShopClass = \App\Support\WelcomeStyleHelper::cardPaddingShopClass($settings->welcome_card_padding);
+        $cardPaddingBlockClass = \App\Support\WelcomeStyleHelper::cardPaddingBlockClass($settings->welcome_card_padding);
+        $cardRadiusClass = \App\Support\WelcomeStyleHelper::cardRadiusClass($settings->welcome_card_radius);
+        $cardShadowClass = \App\Support\WelcomeStyleHelper::cardShadowClass($settings->welcome_card_shadow);
+        $fontStyleClass = \App\Support\WelcomeStyleHelper::fontStyleClass($settings->welcome_font_style);
 
         $toParagraphs = static function (?string $text): array {
             if (! filled($text)) {
@@ -40,7 +46,7 @@
             return array_values(array_filter($parts, static fn (string $part): bool => filled(trim($part))));
         };
     @endphp
-    <body class="min-h-screen {{ $themeBackgroundClass }} text-slate-800 flex p-6 lg:p-10 items-center lg:justify-center flex-col">
+    <body class="min-h-screen {{ $themeBackgroundClass }} {{ $fontStyleClass }} text-slate-800 flex p-6 lg:p-10 items-center lg:justify-center flex-col">
         <header class="w-full lg:max-w-5xl max-w-[340px] text-sm mb-6 not-has-[nav]:hidden">
             @if (Route::has('login'))
                 <nav class="flex justify-end items-center gap-4 flex-wrap">
@@ -67,7 +73,7 @@
 
         <main class="w-full max-w-[340px] lg:max-w-5xl flex-grow mx-auto px-4 py-10">
             <section class="w-full">
-                <div class="rounded-3xl bg-white/70 backdrop-blur-lg border border-white/40 shadow-xl p-8 lg:p-12">
+                <div class="{{ $cardRadiusClass }} bg-white/70 backdrop-blur-lg border border-white/40 {{ $cardShadowClass }} {{ $cardPaddingHeroClass }}">
                     <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-8">
                         <div class="space-y-4 lg:max-w-2xl {{ $heroAlignClass }}">
                             <span class="inline-flex items-center gap-2 px-3 py-1 rounded-full {{ $accentClasses['badge'] }} text-sm font-semibold">{{ $settings->welcome_badge ?: 'sorairo_note' }}</span>
@@ -100,14 +106,14 @@
                     </div>  
                 </div>
                 <div class="mt-10 grid lg:grid-cols-3 gap-6">
-                    <div class="lg:col-span-2 rounded-3xl bg-white/70 backdrop-blur-lg border border-white/40 shadow-xl p-6 lg:p-8">
+                    <div class="lg:col-span-2 {{ $cardRadiusClass }} bg-white/70 backdrop-blur-lg border border-white/40 {{ $cardShadowClass }} {{ $cardPaddingShopClass }}">
                         <h2 class="text-2xl font-bold text-slate-900 mb-4">お店のご案内</h2>
                         @if ($bodyBlocks->isNotEmpty())
                             @php $blockCount = $bodyBlocks->count(); @endphp
                             @if ($blockCount === 1)
                                 {{-- 1件のみはシンプルカード表示 --}}
                                 @foreach ($bodyBlocks as $block)
-                                    <article class="rounded-2xl border border-white/60 bg-white/80 shadow-sm p-5 flex flex-col gap-4">
+                                    <article class="{{ $cardRadiusClass }} border border-white/60 bg-white/80 {{ $cardShadowClass }} {{ $cardPaddingBlockClass }} flex flex-col gap-4">
                                         <div class="flex items-start gap-3">
                                             <span class="w-10 h-10 shrink-0 flex items-center justify-center rounded-full bg-sky-500 text-white font-bold text-sm">1</span>
                                             <div>
@@ -178,7 +184,7 @@
                                             x-show="current === {{ $index }}"
                                             x-transition:enter.duration.350ms
                                             :class="direction === 'right' ? 'slide-enter-right' : 'slide-enter-left'"
-                                            class="rounded-2xl border border-white/60 bg-white/80 shadow-sm p-5 flex flex-col gap-4"
+                                            class="{{ $cardRadiusClass }} border border-white/60 bg-white/80 {{ $cardShadowClass }} {{ $cardPaddingBlockClass }} flex flex-col gap-4"
                                             @if ($index !== 0) style="display:none;" @endif
                                         >
                                             <div class="flex items-start gap-3">
@@ -255,7 +261,7 @@
                         @endif
                     </div>
 
-                    <div class="rounded-3xl bg-gradient-to-br from-sky-200/70 via-white to-cyan-200/70 backdrop-blur-lg border border-white/50 shadow-xl p-6 lg:p-8">
+                    <div class="{{ $cardRadiusClass }} bg-gradient-to-br from-sky-200/70 via-white to-cyan-200/70 backdrop-blur-lg border border-white/50 {{ $cardShadowClass }} {{ $cardPaddingShopClass }}">
                         <h3 class="{{ $shopTitleSizeClass }} font-bold {{ $shopTitleColorClass }} mb-3">{{ $settings->welcome_shop_title ?: '店舗情報' }}</h3>
                         <div class="space-y-3 {{ $shopBodySizeClass }} {{ $shopBodyColorClass }}">
                             @if (filled($settings->welcome_shop_description))


### PR DESCRIPTION
This pull request adds new layout customization options to the Welcome Page, allowing users to adjust card padding, corner radius, shadow, and font style. It updates the settings UI, backend model, migration, preview logic, and both the preview and production views to support these new options.

**Welcome Page Layout Customization**

- Added new fields to the Welcome Page settings for card padding, corner radius, shadow strength, and font style, including corresponding helper texts and options in the Filament resource form. [[1]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bR349-R383) [[2]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bL69-R69)
- Created a new migration to add the corresponding columns (`welcome_card_padding`, `welcome_card_radius`, `welcome_card_shadow`, `welcome_font_style`) to the `system_settings` table.
- Updated the `SystemSetting` model to include the new fields as fillable properties.
- Extended the preview data builder and added helper methods in `WelcomeStyleHelper` to generate the correct Tailwind classes for each new setting. [[1]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bR431-R434) [[2]](diffhunk://#diff-7386ab16e29227f8e34d645ab02950a9682368bc9740ed5aaf7e71f0726ccdfbR208-R260)

**View and Preview Updates**

- Updated both the admin preview (`welcome-preview.blade.php`) and the public welcome page (`welcome.blade.php`) to apply the new layout and font settings dynamically, including responsive handling and correct class application throughout all relevant card elements. [[1]](diffhunk://#diff-ead6744b4aa2387986759c586f4afdd784329679774d63663ea73a3550772f76R18-R27) [[2]](diffhunk://#diff-ead6744b4aa2387986759c586f4afdd784329679774d63663ea73a3550772f76L57-R71) [[3]](diffhunk://#diff-ead6744b4aa2387986759c586f4afdd784329679774d63663ea73a3550772f76L102-R115) [[4]](diffhunk://#diff-ead6744b4aa2387986759c586f4afdd784329679774d63663ea73a3550772f76L158-R171) [[5]](diffhunk://#diff-ead6744b4aa2387986759c586f4afdd784329679774d63663ea73a3550772f76L215-R231) [[6]](diffhunk://#diff-f5a7550e4eed8773041bd7e17639715795e48bbef9a8188c2c12c8226b543c87R31-R36) [[7]](diffhunk://#diff-f5a7550e4eed8773041bd7e17639715795e48bbef9a8188c2c12c8226b543c87L43-R49) [[8]](diffhunk://#diff-f5a7550e4eed8773041bd7e17639715795e48bbef9a8188c2c12c8226b543c87L70-R76) [[9]](diffhunk://#diff-f5a7550e4eed8773041bd7e17639715795e48bbef9a8188c2c12c8226b543c87L103-R116) [[10]](diffhunk://#diff-f5a7550e4eed8773041bd7e17639715795e48bbef9a8188c2c12c8226b543c87L181-R187) [[11]](diffhunk://#diff-f5a7550e4eed8773041bd7e17639715795e48bbef9a8188c2c12c8226b543c87L258-R264)

**Other**

- Prevented the `DatabaseSeeder` from running in production for safety.