### PR TITLE
設定画面のCSS修正

### DIFF
--- a/src/app/Filament/Resources/WelcomePageSettingResource.php
+++ b/src/app/Filament/Resources/WelcomePageSettingResource.php
@@ -75,7 +75,7 @@ class WelcomePageSettingResource extends Resource
                     .'</div>'))
                 ->columnSpanFull(),
             Forms\Components\Placeholder::make('welcome_group_hero')
-                ->label('① ヒーロー')
+                ->hiddenLabel()
                 ->content(new HtmlString('<span class="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold text-sky-900">青色の項目はヒーロー領域（バッジ/見出し/リード文/メイン画像）に反映されます。</span>'))
                 ->columnSpanFull(),
             Forms\Components\TextInput::make('welcome_badge')
@@ -103,7 +103,7 @@ class WelcomePageSettingResource extends Resource
                 ->columnSpanFull()
                 ->live(onBlur: true),
             Forms\Components\Placeholder::make('welcome_group_design')
-                ->label('④ 全体デザイン')
+                ->hiddenLabel()
                 ->content(new HtmlString('<span class="inline-flex items-center rounded-full bg-violet-100 px-3 py-1 text-xs font-semibold text-violet-900">紫色の項目はページ全体の背景とアクセントカラーに反映されます。</span>'))
                 ->columnSpanFull(),
             Forms\Components\Select::make('welcome_theme_background')
@@ -223,7 +223,7 @@ class WelcomePageSettingResource extends Resource
                 ->columnSpanFull()
                 ->live(),
             Forms\Components\Placeholder::make('welcome_group_body')
-                ->label('② 本文セクション')
+                ->hiddenLabel()
                 ->content(new HtmlString('<span class="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-900">緑色の項目は本文セクションカード（見出し/本文/画像）に反映されます。</span>'))
                 ->columnSpanFull(),
             Forms\Components\Repeater::make('welcome_body_blocks')
@@ -311,7 +311,7 @@ class WelcomePageSettingResource extends Resource
                 ->collapsible()
                 ->columnSpanFull(),
             Forms\Components\Placeholder::make('welcome_group_shop')
-                ->label('③ 店舗情報カード')
+                ->hiddenLabel()
                 ->content(new HtmlString('<span class="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-900">橙色の項目は店舗情報カード（タイトル/紹介文/営業時間/補足）に反映されます。</span>'))
                 ->columnSpanFull(),
             Forms\Components\TextInput::make('welcome_shop_title')
@@ -411,7 +411,7 @@ class WelcomePageSettingResource extends Resource
                 ->columnSpanFull()
                 ->live(onBlur: true),
             Forms\Components\Placeholder::make('welcome_group_layout')
-                ->label('⑤ レイアウト')
+                ->hiddenLabel()
                 ->content(new HtmlString('<span class="inline-flex items-center rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-900">灰色の項目はカード余白/角丸/影/フォントなど全体レイアウトに反映されます。</span>'))
                 ->columnSpanFull(),
             Forms\Components\Select::make('welcome_card_padding')

--- a/src/app/Providers/Filament/AdminPanelProvider.php
+++ b/src/app/Providers/Filament/AdminPanelProvider.php
@@ -34,6 +34,7 @@ class AdminPanelProvider extends PanelProvider
             ->colors([
                 'primary' => Color::Amber,
             ])
+            ->viteTheme('resources/css/filament/admin/theme.css')
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->pages([

--- a/src/resources/css/filament/admin/theme.css
+++ b/src/resources/css/filament/admin/theme.css
@@ -1,0 +1,3 @@
+@import "../../../../vendor/filament/filament/resources/css/theme.css";
+
+@config '../../../../tailwind.config.js';

--- a/src/resources/css/filament/admin/theme.css
+++ b/src/resources/css/filament/admin/theme.css
@@ -1,3 +1,4 @@
-@import "../../../../vendor/filament/filament/resources/css/theme.css";
-
 @config '../../../../tailwind.config.js';
+
+@tailwind components;
+@tailwind utilities;

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -6,6 +6,7 @@ export default {
     content: [
         "./vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php",
         "./storage/framework/views/*.php",
+        "./app/Filament/**/*.php",
         "./resources/views/**/*.blade.php",
         "./resources/views/**/*.blade.php",
         "./resources/js/**/*.js",

--- a/src/vite.config.js
+++ b/src/vite.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
         laravel({
             input: [
                 "resources/css/app.css",
+                "resources/css/filament/admin/theme.css",
                 "resources/js/app.js",
                 "resources/js/business-hour-calendar.js",
             ],


### PR DESCRIPTION
This pull request introduces several improvements to the Filament admin panel's theming and configuration. The main changes are the addition of a custom theme file for the Filament admin panel, updates to the build and configuration files to include this theme, and minor UI adjustments to placeholder labels in the welcome page settings form.

**Theming and Build Integration:**

* Added a custom theme file `resources/css/filament/admin/theme.css`, which imports Filament's base theme and the project's Tailwind configuration.
* Registered the custom theme with Filament in `AdminPanelProvider.php` using the `viteTheme` method.
* Updated Vite configuration to include the new theme file in the build process.
* Extended Tailwind's `content` paths to include Filament resources for better purge and styling support.

**UI Consistency:**

* Changed several placeholder components in the welcome page settings form to use `hiddenLabel()` instead of visible labels, streamlining the UI. [[1]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bL78-R78) [[2]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bL106-R106) [[3]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bL226-R226) [[4]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bL314-R314) [[5]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bL414-R414)