### PR TITLE
管理者側からの予約ができるように修正、カレンダーUI修正

### DIFF
--- a/src/app/Filament/Resources/ReservationResource/Pages/ManageReservationCalendar.php
+++ b/src/app/Filament/Resources/ReservationResource/Pages/ManageReservationCalendar.php
@@ -721,6 +721,10 @@ class ManageReservationCalendar extends Page
         }
 
         $activeOptions = $this->resolveActiveMenuOptions($menu);
+        $activeOptionIds = $activeOptions
+            ->pluck('id')
+            ->map(fn ($id): int => (int) $id)
+            ->all();
         $requestedOptionIds = collect($this->directReservationOptionIds)
             ->map(fn ($id): int => (int) $id)
             ->filter(fn (int $id): bool => $id > 0)
@@ -728,7 +732,7 @@ class ManageReservationCalendar extends Page
             ->values();
 
         $selectedOptionIds = $requestedOptionIds
-            ->filter(fn ($id): bool => in_array((int) $id, $activeOptions->pluck('id')->all(), true))
+            ->filter(fn ($id): bool => in_array((int) $id, $activeOptionIds, true))
             ->map(fn ($id): int => (int) $id)
             ->values();
 
@@ -738,15 +742,22 @@ class ManageReservationCalendar extends Page
             ]);
         }
 
-        $totalDuration = (int) $menu->duration + (int) $activeOptions
-            ->whereIn('id', $selectedOptionIds->all())
-            ->sum('duration');
+        $selectedOptionDuration = $selectedOptionIds->isNotEmpty()
+            ? (int) MenuOption::query()
+                ->where('menu_id', $menu->id)
+                ->whereIn('id', $selectedOptionIds->all())
+                ->sum('duration')
+            : 0;
 
-        if ($totalDuration <= 0 || $startAt->diffInMinutes($endAt) !== $totalDuration) {
+        $totalDuration = (int) $menu->duration + $selectedOptionDuration;
+
+        if ($totalDuration <= 0) {
             throw ValidationException::withMessages([
                 'duration' => '選択した時間帯がメニュー所要時間と一致しません。',
             ]);
         }
+
+        $resolvedEndAt = $startAt->copy()->addMinutes($totalDuration);
 
         $availabilityService = new AvailabilityService;
         $availableTimes = $availabilityService->getAvailableTimes($menu, $selectedOptionIds->all(), $startAt->toDateString());
@@ -756,7 +767,7 @@ class ManageReservationCalendar extends Page
             ]);
         }
 
-        DB::transaction(function () use ($user, $menu, $startAt, $endAt, $selectedOptionIds): void {
+        DB::transaction(function () use ($user, $menu, $startAt, $resolvedEndAt, $selectedOptionIds): void {
             Reservation::query()
                 ->whereDate('date', $startAt->toDateString())
                 ->where('status', 'confirmed')
@@ -777,7 +788,7 @@ class ManageReservationCalendar extends Page
                 'slot_id' => null,
                 'date' => $startAt->toDateString(),
                 'start_time' => $startAt->format('H:i'),
-                'end_time' => $endAt->format('H:i'),
+                'end_time' => $resolvedEndAt->format('H:i'),
                 'status' => 'confirmed',
             ]);
 
@@ -858,6 +869,7 @@ class ManageReservationCalendar extends Page
                 ->where('slot_id', $slot->id)
                 ->where('status', 'confirmed')
                 ->lockForUpdate()
+                ->get(['id'])
                 ->count();
 
             if ($slot->capacity === null || $confirmedCount >= $slot->capacity) {

--- a/src/app/Filament/Resources/ReservationResource/Pages/ManageReservationCalendar.php
+++ b/src/app/Filament/Resources/ReservationResource/Pages/ManageReservationCalendar.php
@@ -3,15 +3,23 @@
 namespace App\Filament\Resources\ReservationResource\Pages;
 
 use App\Filament\Resources\ReservationResource;
+use App\Models\BusinessHour;
+use App\Models\Menu;
+use App\Models\MenuOption;
 use App\Models\Reservation;
 use App\Models\Slot;
 use App\Models\TimeBlock;
+use App\Models\User;
+use App\Services\AvailabilityService;
 use Carbon\Carbon;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\Page;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 
 class ManageReservationCalendar extends Page
 {
@@ -32,6 +40,18 @@ class ManageReservationCalendar extends Page
     public ?string $pendingBlockStart = null;
 
     public ?string $pendingBlockEnd = null;
+
+    public ?string $pendingDirectReservationStart = null;
+
+    public ?string $pendingDirectReservationEnd = null;
+
+    public ?int $directReservationUserId = null;
+
+    public ?int $directReservationMenuId = null;
+
+    public array $directReservationOptionIds = [];
+
+    public ?int $directReservationSlotId = null;
 
     protected function getHeaderActions(): array
     {
@@ -80,11 +100,50 @@ class ManageReservationCalendar extends Page
 
     public function setOperationMode(string $mode): void
     {
-        if (! in_array($mode, ['reservation', 'block'], true)) {
+        if (! in_array($mode, ['reservation', 'block', 'direct'], true)) {
             return;
         }
 
         $this->operationMode = $mode;
+    }
+
+    public function updatedDirectReservationMenuId(): void
+    {
+        $this->directReservationOptionIds = [];
+        $this->directReservationSlotId = null;
+    }
+
+    public function showDirectReservationModal(string $start, string $end): void
+    {
+        $this->pendingDirectReservationStart = $start;
+        $this->pendingDirectReservationEnd = $end;
+        $this->directReservationOptionIds = [];
+        $this->directReservationSlotId = null;
+
+        $this->dispatch('open-modal', id: 'direct-reservation-create-confirm');
+    }
+
+    public function confirmCreateDirectReservation(): void
+    {
+        if (! $this->pendingDirectReservationStart || ! $this->pendingDirectReservationEnd) {
+            return;
+        }
+
+        $created = $this->createDirectReservationFromCalendar(
+            $this->pendingDirectReservationStart,
+            $this->pendingDirectReservationEnd,
+        );
+
+        if (! $created) {
+            return;
+        }
+
+        $this->pendingDirectReservationStart = null;
+        $this->pendingDirectReservationEnd = null;
+        $this->directReservationOptionIds = [];
+        $this->directReservationSlotId = null;
+
+        $this->dispatch('close-modal', id: 'direct-reservation-create-confirm');
     }
 
     public function showBlockConfirmModal(string $start, string $end): void
@@ -132,6 +191,70 @@ class ManageReservationCalendar extends Page
             ->send();
 
         $this->dispatch('reservation-calendar-refetch');
+    }
+
+    public function createDirectReservationFromCalendar(string $start, string $end): bool
+    {
+        try {
+            if (! Auth::user()?->is_admin) {
+                throw ValidationException::withMessages([
+                    'auth' => 'この操作を実行する権限がありません。',
+                ]);
+            }
+
+            $startAt = Carbon::parse($start, 'Asia/Tokyo');
+            $endAt = Carbon::parse($end, 'Asia/Tokyo');
+
+            if ($startAt->gte($endAt) || $startAt->diffInMinutes($endAt) % 30 !== 0) {
+                throw ValidationException::withMessages([
+                    'range' => '30分単位で正しい時間範囲を指定してください。',
+                ]);
+            }
+
+            if (! $this->directReservationUserId) {
+                throw ValidationException::withMessages([
+                    'user_id' => '利用者を選択してください。',
+                ]);
+            }
+
+            if (! $this->directReservationMenuId) {
+                throw ValidationException::withMessages([
+                    'menu_id' => 'メニューを選択してください。',
+                ]);
+            }
+
+            $user = User::query()->find($this->directReservationUserId);
+            $menu = Menu::query()->find($this->directReservationMenuId);
+
+            if (! $user || ! $menu || ! $menu->is_active) {
+                throw ValidationException::withMessages([
+                    'menu_id' => '利用者またはメニューの指定が不正です。',
+                ]);
+            }
+
+            if ($this->hasTimeBlockConflict($startAt, $endAt)) {
+                throw ValidationException::withMessages([
+                    'range' => '選択した時間帯はブロックされているため予約できません。',
+                ]);
+            }
+
+            if ($menu->is_event) {
+                return $this->createDirectEventReservation($user, $menu, $startAt, $endAt);
+            }
+
+            return $this->createDirectTreatmentReservation($user, $menu, $startAt, $endAt);
+        } catch (ValidationException $e) {
+            $message = collect($e->errors())
+                ->flatten()
+                ->first() ?? 'ダイレクト予約の作成に失敗しました。';
+
+            Notification::make()
+                ->title((string) $message)
+                ->danger()
+                ->send();
+
+            return false;
+        }
     }
 
     public function updateBlockFromCalendar(int $blockId, string $start, string $end): void
@@ -568,5 +691,303 @@ class ManageReservationCalendar extends Page
     protected function formatPrice(int $price): string
     {
         return '¥'.number_format($price);
+    }
+
+    protected function createDirectTreatmentReservation(User $user, Menu $menu, Carbon $startAt, Carbon $endAt): bool
+    {
+        $businessSetting = BusinessHour::getSettingForDate($startAt->copy()->startOfDay());
+
+        if (! $businessSetting || $businessSetting->is_closed) {
+            throw ValidationException::withMessages([
+                'business_hour' => '選択した日は営業時間外のため予約できません。',
+            ]);
+        }
+
+        $openAt = Carbon::createFromFormat(
+            'Y-m-d H:i:s',
+            $startAt->toDateString().' '.Carbon::parse((string) $businessSetting->open_time)->format('H:i:s'),
+            'Asia/Tokyo',
+        );
+        $closeAt = Carbon::createFromFormat(
+            'Y-m-d H:i:s',
+            $startAt->toDateString().' '.Carbon::parse((string) $businessSetting->close_time)->format('H:i:s'),
+            'Asia/Tokyo',
+        );
+
+        if ($startAt->lt($openAt) || $endAt->gt($closeAt)) {
+            throw ValidationException::withMessages([
+                'business_hour' => '営業時間内の時間帯を選択してください。',
+            ]);
+        }
+
+        $activeOptions = $this->resolveActiveMenuOptions($menu);
+        $requestedOptionIds = collect($this->directReservationOptionIds)
+            ->map(fn ($id): int => (int) $id)
+            ->filter(fn (int $id): bool => $id > 0)
+            ->unique()
+            ->values();
+
+        $selectedOptionIds = $requestedOptionIds
+            ->filter(fn ($id): bool => in_array((int) $id, $activeOptions->pluck('id')->all(), true))
+            ->map(fn ($id): int => (int) $id)
+            ->values();
+
+        if ($requestedOptionIds->count() !== $selectedOptionIds->count()) {
+            throw ValidationException::withMessages([
+                'options' => '選択したオプションに無効な項目が含まれています。',
+            ]);
+        }
+
+        $totalDuration = (int) $menu->duration + (int) $activeOptions
+            ->whereIn('id', $selectedOptionIds->all())
+            ->sum('duration');
+
+        if ($totalDuration <= 0 || $startAt->diffInMinutes($endAt) !== $totalDuration) {
+            throw ValidationException::withMessages([
+                'duration' => '選択した時間帯がメニュー所要時間と一致しません。',
+            ]);
+        }
+
+        $availabilityService = new AvailabilityService;
+        $availableTimes = $availabilityService->getAvailableTimes($menu, $selectedOptionIds->all(), $startAt->toDateString());
+        if (! in_array($startAt->format('H:i'), $availableTimes, true)) {
+            throw ValidationException::withMessages([
+                'start_time' => 'この時間帯は既に予約されています。',
+            ]);
+        }
+
+        DB::transaction(function () use ($user, $menu, $startAt, $endAt, $selectedOptionIds): void {
+            Reservation::query()
+                ->whereDate('date', $startAt->toDateString())
+                ->where('status', 'confirmed')
+                ->lockForUpdate()
+                ->get();
+
+            $availabilityService = new AvailabilityService;
+            $availableTimes = $availabilityService->getAvailableTimes($menu, $selectedOptionIds->all(), $startAt->toDateString());
+            if (! in_array($startAt->format('H:i'), $availableTimes, true)) {
+                throw ValidationException::withMessages([
+                    'start_time' => 'この時間帯は既に予約されています。',
+                ]);
+            }
+
+            $reservation = Reservation::create([
+                'user_id' => $user->id,
+                'menu_id' => $menu->id,
+                'slot_id' => null,
+                'date' => $startAt->toDateString(),
+                'start_time' => $startAt->format('H:i'),
+                'end_time' => $endAt->format('H:i'),
+                'status' => 'confirmed',
+            ]);
+
+            if ($selectedOptionIds->isNotEmpty()) {
+                $reservation->options()->attach($selectedOptionIds->all());
+            }
+        });
+
+        Notification::make()
+            ->title('ダイレクト予約を作成しました。')
+            ->success()
+            ->send();
+
+        $this->dispatch('reservation-calendar-refetch');
+
+        return true;
+    }
+
+    protected function createDirectEventReservation(User $user, Menu $menu, Carbon $startAt, Carbon $endAt): bool
+    {
+        if (! $this->directReservationSlotId) {
+            throw ValidationException::withMessages([
+                'slot_id' => 'イベント時間枠を選択してください。',
+            ]);
+        }
+
+        DB::transaction(function () use ($user, $menu, $startAt, $endAt): void {
+            $slot = Slot::query()
+                ->with('menu')
+                ->whereKey($this->directReservationSlotId)
+                ->lockForUpdate()
+                ->first();
+
+            if (! $slot || $slot->menu_id !== $menu->id) {
+                throw ValidationException::withMessages([
+                    'slot_id' => '選択したイベント時間枠を確認できませんでした。',
+                ]);
+            }
+
+            $slotStartAt = Carbon::createFromFormat(
+                'Y-m-d H:i:s',
+                $slot->date->toDateString().' '.$slot->start_time->format('H:i:s'),
+                'Asia/Tokyo',
+            );
+            $slotEndAt = Carbon::createFromFormat(
+                'Y-m-d H:i:s',
+                $slot->date->toDateString().' '.$slot->end_time->format('H:i:s'),
+                'Asia/Tokyo',
+            );
+
+            if (! $slotStartAt->equalTo($startAt) || ! $slotEndAt->equalTo($endAt)) {
+                throw ValidationException::withMessages([
+                    'slot_id' => 'カレンダーで選択した時間帯とイベント時間枠が一致しません。',
+                ]);
+            }
+
+            if ($this->hasTimeBlockConflict($slotStartAt, $slotEndAt)) {
+                throw ValidationException::withMessages([
+                    'slot_id' => '選択したイベント時間枠はブロックされているため予約できません。',
+                ]);
+            }
+
+            $alreadyReserved = Reservation::query()
+                ->where('user_id', $user->id)
+                ->where('menu_id', $menu->id)
+                ->whereDate('date', $slot->date->toDateString())
+                ->where('status', 'confirmed')
+                ->lockForUpdate()
+                ->exists();
+
+            if ($alreadyReserved) {
+                throw ValidationException::withMessages([
+                    'slot_id' => '同じイベントは1日につき1回まで予約できます。',
+                ]);
+            }
+
+            $confirmedCount = Reservation::query()
+                ->where('slot_id', $slot->id)
+                ->where('status', 'confirmed')
+                ->lockForUpdate()
+                ->count();
+
+            if ($slot->capacity === null || $confirmedCount >= $slot->capacity) {
+                throw ValidationException::withMessages([
+                    'slot_id' => 'このイベント枠は満席です。',
+                ]);
+            }
+
+            Reservation::create([
+                'user_id' => $user->id,
+                'menu_id' => $menu->id,
+                'slot_id' => $slot->id,
+                'date' => $slot->date->toDateString(),
+                'start_time' => $slot->start_time->format('H:i'),
+                'end_time' => $slot->end_time->format('H:i'),
+                'status' => 'confirmed',
+            ]);
+        });
+
+        Notification::make()
+            ->title('イベントのダイレクト予約を作成しました。')
+            ->success()
+            ->send();
+
+        $this->dispatch('reservation-calendar-refetch');
+
+        return true;
+    }
+
+    protected function hasTimeBlockConflict(Carbon $startAt, Carbon $endAt): bool
+    {
+        return TimeBlock::query()
+            ->where('is_active', true)
+            ->where('start_at', '<', $endAt)
+            ->where('end_at', '>', $startAt)
+            ->exists();
+    }
+
+    protected function resolveActiveMenuOptions(Menu $menu): Collection
+    {
+        return MenuOption::query()
+            ->where('menu_id', $menu->id)
+            ->active()
+            ->get();
+    }
+
+    public function getDirectReservationUsers(): array
+    {
+        return User::query()
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->map(fn (User $user): array => [
+                'id' => $user->id,
+                'name' => $user->name,
+            ])
+            ->all();
+    }
+
+    public function getDirectReservationMenus(): array
+    {
+        return Menu::query()
+            ->where('is_active', true)
+            ->orderedByTypeForDisplay()
+            ->get(['id', 'name', 'is_event'])
+            ->map(fn (Menu $menu): array => [
+                'id' => $menu->id,
+                'name' => $menu->name,
+                'is_event' => (bool) $menu->is_event,
+            ])
+            ->all();
+    }
+
+    public function getDirectReservationMenuOptions(): array
+    {
+        if (! $this->directReservationMenuId) {
+            return [];
+        }
+
+        $menu = Menu::query()->find($this->directReservationMenuId);
+        if (! $menu || $menu->is_event) {
+            return [];
+        }
+
+        return $this->resolveActiveMenuOptions($menu)
+            ->map(fn (MenuOption $option): array => [
+                'id' => $option->id,
+                'name' => $option->name,
+                'duration' => (int) $option->duration,
+                'price' => (int) $option->price,
+            ])
+            ->all();
+    }
+
+    public function getDirectReservationEventSlots(): array
+    {
+        if (! $this->directReservationMenuId || ! $this->pendingDirectReservationStart || ! $this->pendingDirectReservationEnd) {
+            return [];
+        }
+
+        $menu = Menu::query()->find($this->directReservationMenuId);
+        if (! $menu || ! $menu->is_event) {
+            return [];
+        }
+
+        $startAt = Carbon::parse($this->pendingDirectReservationStart, 'Asia/Tokyo');
+        $endAt = Carbon::parse($this->pendingDirectReservationEnd, 'Asia/Tokyo');
+
+        return Slot::query()
+            ->withCount([
+                'reservations as confirmed_reservations_count' => fn (Builder $query) => $query->where('status', 'confirmed'),
+            ])
+            ->where('menu_id', $menu->id)
+            ->whereDate('date', $startAt->toDateString())
+            ->where('start_time', $startAt->format('H:i'))
+            ->where('end_time', $endAt->format('H:i'))
+            ->orderBy('start_time')
+            ->get()
+            ->map(function (Slot $slot): array {
+                $remainingCapacity = $slot->remainingCapacity();
+
+                return [
+                    'id' => $slot->id,
+                    'label' => sprintf(
+                        '%s - %s（残り %s名）',
+                        $slot->start_time->format('H:i'),
+                        $slot->end_time->format('H:i'),
+                        $remainingCapacity !== null ? (string) $remainingCapacity : '未設定'
+                    ),
+                ];
+            })
+            ->all();
     }
 }

--- a/src/resources/js/business-hour-calendar.js
+++ b/src/resources/js/business-hour-calendar.js
@@ -38,7 +38,7 @@ import timeGridPlugin from "@fullcalendar/timegrid";
             editable: false,
             height: "auto",
             headerToolbar: {
-                left: "today",
+                left: "prev,next today",
                 center: "title",
                 right: "dayGridMonth,timeGridWeek,timeGridDay",
             },

--- a/src/resources/views/filament/resources/reservation-resource/pages/manage-reservation-calendar.blade.php
+++ b/src/resources/views/filament/resources/reservation-resource/pages/manage-reservation-calendar.blade.php
@@ -71,6 +71,22 @@
                             <span class="ml-1 rounded-full bg-white/30 px-1.5 py-0.5 text-xs font-bold leading-none">ON</span>
                         @endif
                     </button>
+                    <button
+                        type="button"
+                        wire:click="setOperationMode('direct')"
+                        class="inline-flex items-center gap-1.5 rounded-lg border px-4 py-2 text-sm font-semibold shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-offset-2
+                            {{ $operationMode === 'direct'
+                                ? 'border-emerald-600 bg-emerald-500 text-white shadow-emerald-200 focus:ring-emerald-400'
+                                : 'border-slate-300 bg-white text-slate-500 hover:border-emerald-400 hover:bg-emerald-50 hover:text-emerald-700 focus:ring-emerald-200' }}"
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10m-1 9H8a3 3 0 01-3-3V8a3 3 0 013-3h8a3 3 0 013 3v9a3 3 0 01-3 3z" />
+                        </svg>
+                        ダイレクト予約
+                        @if ($operationMode === 'direct')
+                            <span class="ml-1 rounded-full bg-white/30 px-1.5 py-0.5 text-xs font-bold leading-none">ON</span>
+                        @endif
+                    </button>
                 </div>
 
                 @if ($operationMode === 'block')
@@ -84,9 +100,11 @@
                 @endif
             </div>
 
-            <p class="mt-2 text-xs {{ $operationMode === 'block' ? 'text-red-700' : 'text-slate-500' }}">
+            <p class="mt-2 text-xs {{ $operationMode === 'block' ? 'text-red-700' : ($operationMode === 'direct' ? 'text-emerald-700' : 'text-slate-500') }}">
                 @if ($operationMode === 'block')
                     カレンダーをドラッグして予約不可の時間帯ブロックを作成できます。作成後はドラッグ・リサイズで調整、クリックで削除できます。
+                @elseif ($operationMode === 'direct')
+                    カレンダーをドラッグするとダイレクト予約作成モーダルを開きます。ブロック時間帯は予約できません。
                 @else
                     予約をクリックすると予約詳細、イベント枠をクリックするとイベント枠詳細を表示します。
                 @endif
@@ -310,6 +328,130 @@
                     閉じる
                 </x-filament::button>
             </div>
+        </x-slot>
+    </x-filament::modal>
+
+    <x-filament::modal
+        id="direct-reservation-create-confirm"
+        width="2xl"
+        icon="heroicon-o-calendar-days"
+        icon-color="success"
+        sticky-header
+    >
+        <x-slot name="heading">
+            ダイレクト予約の確認
+        </x-slot>
+
+        <x-slot name="description">
+            ユーザーとメニューを選択し、カレンダーで選んだ時間帯で予約を確定します。
+        </x-slot>
+
+        @php
+            $selectedMenu = collect($this->getDirectReservationMenus())->firstWhere('id', $directReservationMenuId);
+            $isEventMenu = (bool) ($selectedMenu['is_event'] ?? false);
+            $directUsers = $this->getDirectReservationUsers();
+            $directMenus = $this->getDirectReservationMenus();
+            $directOptions = $this->getDirectReservationMenuOptions();
+            $directSlots = $this->getDirectReservationEventSlots();
+        @endphp
+
+        <div class="space-y-4">
+            @if ($pendingDirectReservationStart && $pendingDirectReservationEnd)
+                <div class="rounded-lg border border-emerald-100 bg-emerald-50 px-4 py-3">
+                    <p class="text-xs font-medium uppercase tracking-wide text-emerald-600">選択時間帯</p>
+                    <p class="mt-1 text-base font-semibold text-emerald-800">
+                        {{ \Carbon\Carbon::parse($pendingDirectReservationStart)->timezone('Asia/Tokyo')->format('Y年n月j日 H:i') }}
+                        〜
+                        {{ \Carbon\Carbon::parse($pendingDirectReservationEnd)->timezone('Asia/Tokyo')->format('H:i') }}
+                    </p>
+                </div>
+            @endif
+
+            <div class="grid gap-4 md:grid-cols-2">
+                <label class="space-y-1">
+                    <span class="text-sm font-semibold text-slate-700">ユーザー</span>
+                    <select
+                        wire:model.live="directReservationUserId"
+                        class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-emerald-400 focus:outline-none focus:ring-1 focus:ring-emerald-400"
+                    >
+                        <option value="">選択してください</option>
+                        @foreach ($directUsers as $user)
+                            <option value="{{ $user['id'] }}">{{ $user['name'] }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-1">
+                    <span class="text-sm font-semibold text-slate-700">メニュー</span>
+                    <select
+                        wire:model.live="directReservationMenuId"
+                        class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-emerald-400 focus:outline-none focus:ring-1 focus:ring-emerald-400"
+                    >
+                        <option value="">選択してください</option>
+                        @foreach ($directMenus as $menu)
+                            <option value="{{ $menu['id'] }}">
+                                {{ $menu['name'] }}{{ $menu['is_event'] ? '（イベント）' : '' }}
+                            </option>
+                        @endforeach
+                    </select>
+                </label>
+            </div>
+
+            @if ($directReservationMenuId)
+                @if ($isEventMenu)
+                    <label class="space-y-1">
+                        <span class="text-sm font-semibold text-slate-700">イベント時間枠</span>
+                        <select
+                            wire:model.live="directReservationSlotId"
+                            class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-emerald-400 focus:outline-none focus:ring-1 focus:ring-emerald-400"
+                        >
+                            <option value="">選択してください</option>
+                            @foreach ($directSlots as $slot)
+                                <option value="{{ $slot['id'] }}">{{ $slot['label'] }}</option>
+                            @endforeach
+                        </select>
+                    </label>
+
+                    @if (empty($directSlots))
+                        <p class="text-xs text-amber-700">選択した時間帯に一致するイベント時間枠がありません。カレンダー上で枠の時間を選択してください。</p>
+                    @endif
+                @elseif (! empty($directOptions))
+                    <div class="space-y-2">
+                        <p class="text-sm font-semibold text-slate-700">追加オプション</p>
+                        <div class="grid gap-2 sm:grid-cols-2">
+                            @foreach ($directOptions as $option)
+                                <label class="flex items-start gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm">
+                                    <input
+                                        type="checkbox"
+                                        value="{{ $option['id'] }}"
+                                        wire:model.live="directReservationOptionIds"
+                                        class="mt-1 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
+                                    >
+                                    <span class="min-w-0">
+                                        <span class="block font-medium text-slate-800">{{ $option['name'] }}</span>
+                                        <span class="block text-xs text-slate-500">+{{ $option['duration'] }}分 / ¥{{ number_format($option['price']) }}</span>
+                                    </span>
+                                </label>
+                            @endforeach
+                        </div>
+                    </div>
+                @endif
+            @endif
+        </div>
+
+        <x-slot name="footerActions">
+            <x-filament::button
+                color="success"
+                wire:click="confirmCreateDirectReservation"
+            >
+                予約する
+            </x-filament::button>
+            <x-filament::button
+                color="gray"
+                x-on:click="$dispatch('close-modal', { id: 'direct-reservation-create-confirm' })"
+            >
+                キャンセル
+            </x-filament::button>
         </x-slot>
     </x-filament::modal>
 
@@ -850,14 +992,26 @@
                     select: (info) => {
                         const operationMode = livewireComponent.get('operationMode');
 
+                        if (operationMode === 'block') {
+                            livewireComponent
+                                .call('showBlockConfirmModal', info.startStr, info.endStr)
+                                .finally(() => calendar.unselect());
+
+                            return;
+                        }
+
+                        if (operationMode === 'direct') {
+                            livewireComponent
+                                .call('showDirectReservationModal', info.startStr, info.endStr)
+                                .finally(() => calendar.unselect());
+
+                            return;
+                        }
+
                         if (operationMode !== 'block') {
                             calendar.unselect();
                             return;
                         }
-
-                        livewireComponent
-                            .call('showBlockConfirmModal', info.startStr, info.endStr)
-                            .finally(() => calendar.unselect());
                     },
                     eventDrop: (info) => {
                         const eventType = info.event.extendedProps && info.event.extendedProps.type;

--- a/src/tests/Feature/AdminReservationCalendarTest.php
+++ b/src/tests/Feature/AdminReservationCalendarTest.php
@@ -47,7 +47,9 @@ class AdminReservationCalendarTest extends TestCase
             'duration' => 0,
         ]);
 
-        $date = now('Asia/Tokyo')->addDay()->toDateString();
+        $rangeStart = now('Asia/Tokyo')->startOfWeek();
+        $rangeEndExclusive = now('Asia/Tokyo')->endOfWeek()->addDay();
+        $date = $rangeStart->copy()->addDay()->toDateString();
         $slot = Slot::create([
             'menu_id' => $menu->id,
             'date' => $date,
@@ -61,8 +63,8 @@ class AdminReservationCalendarTest extends TestCase
 
         $page = app(ManageReservationCalendar::class);
         $events = $page->getCalendarEvents(
-            now('Asia/Tokyo')->startOfWeek()->toIso8601String(),
-            now('Asia/Tokyo')->endOfWeek()->addDay()->toIso8601String(),
+            $rangeStart->toIso8601String(),
+            $rangeEndExclusive->toIso8601String(),
         );
 
         $slotEvent = collect($events)->first(fn (array $event): bool => ($event['id'] ?? null) === 'slot-'.$slot->id);
@@ -165,9 +167,8 @@ class AdminReservationCalendarTest extends TestCase
         $start = $date->copy()->setTime(11, 0, 0);
         $end = $date->copy()->setTime(12, 30, 0);
 
-        $this->actingAs($admin);
-
-        Livewire::test(ManageReservationCalendar::class)
+        Livewire::actingAs($admin)
+            ->test(ManageReservationCalendar::class)
             ->set('directReservationUserId', $customer->id)
             ->set('directReservationMenuId', $menu->id)
             ->set('directReservationOptionIds', [$option->id])
@@ -212,9 +213,8 @@ class AdminReservationCalendarTest extends TestCase
             'is_active' => true,
         ]);
 
-        $this->actingAs($admin);
-
-        Livewire::test(ManageReservationCalendar::class)
+        Livewire::actingAs($admin)
+            ->test(ManageReservationCalendar::class)
             ->set('directReservationUserId', $customer->id)
             ->set('directReservationMenuId', $menu->id)
             ->call('createDirectReservationFromCalendar', $start->toIso8601String(), $end->toIso8601String());
@@ -252,9 +252,8 @@ class AdminReservationCalendarTest extends TestCase
             'is_reserved' => false,
         ]);
 
-        $this->actingAs($admin);
-
-        Livewire::test(ManageReservationCalendar::class)
+        Livewire::actingAs($admin)
+            ->test(ManageReservationCalendar::class)
             ->set('directReservationUserId', $customer1->id)
             ->set('directReservationMenuId', $eventMenu->id)
             ->set('directReservationSlotId', $slot->id)
@@ -272,7 +271,8 @@ class AdminReservationCalendarTest extends TestCase
             'status' => 'confirmed',
         ]);
 
-        Livewire::test(ManageReservationCalendar::class)
+        Livewire::actingAs($admin)
+            ->test(ManageReservationCalendar::class)
             ->set('directReservationUserId', $customer2->id)
             ->set('directReservationMenuId', $eventMenu->id)
             ->set('directReservationSlotId', $slot->id)

--- a/src/tests/Feature/AdminReservationCalendarTest.php
+++ b/src/tests/Feature/AdminReservationCalendarTest.php
@@ -3,11 +3,16 @@
 namespace Tests\Feature;
 
 use App\Filament\Resources\ReservationResource\Pages\ManageReservationCalendar;
+use App\Models\BusinessHour;
 use App\Models\Menu;
+use App\Models\MenuOption;
 use App\Models\Reservation;
 use App\Models\Slot;
+use App\Models\TimeBlock;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
 use Tests\TestCase;
 
 class AdminReservationCalendarTest extends TestCase
@@ -131,5 +136,163 @@ class AdminReservationCalendarTest extends TestCase
         $endedResponse->assertOk();
         $endedResponse->assertSee('/admin/reservations/'.$pastReservation->id.'/edit', false);
         $endedResponse->assertDontSee('/admin/reservations/'.$futureReservation->id.'/edit', false);
+    }
+
+    public function test_admin_can_create_direct_treatment_reservation_from_calendar(): void
+    {
+        $admin = User::factory()->create([
+            'is_admin' => true,
+        ]);
+        $customer = User::factory()->create();
+
+        $menu = Menu::factory()->create([
+            'is_event' => false,
+            'duration' => 60,
+            'price' => 7000,
+            'is_active' => true,
+        ]);
+        $option = MenuOption::create([
+            'menu_id' => $menu->id,
+            'name' => 'ヘッドマッサージ',
+            'price' => 1000,
+            'duration' => 30,
+            'is_active' => true,
+        ]);
+
+        $date = now('Asia/Tokyo')->addDays(2)->startOfDay();
+        $this->createBusinessHour($date, '10:00:00', '20:00:00');
+
+        $start = $date->copy()->setTime(11, 0, 0);
+        $end = $date->copy()->setTime(12, 30, 0);
+
+        $this->actingAs($admin);
+
+        Livewire::test(ManageReservationCalendar::class)
+            ->set('directReservationUserId', $customer->id)
+            ->set('directReservationMenuId', $menu->id)
+            ->set('directReservationOptionIds', [$option->id])
+            ->call('createDirectReservationFromCalendar', $start->toIso8601String(), $end->toIso8601String())
+            ->assertSet('directReservationMenuId', $menu->id);
+
+        $reservation = Reservation::query()->where('user_id', $customer->id)->latest('id')->first();
+
+        $this->assertNotNull($reservation);
+        $this->assertSame($menu->id, $reservation->menu_id);
+        $this->assertNull($reservation->slot_id);
+        $this->assertSame($start->toDateString(), $reservation->date->toDateString());
+        $this->assertSame('11:00', $reservation->start_time->format('H:i'));
+        $this->assertSame('12:30', $reservation->end_time->format('H:i'));
+        $this->assertSame('confirmed', $reservation->status);
+        $this->assertSame([$option->id], $reservation->options()->pluck('menu_option_id')->all());
+    }
+
+    public function test_direct_reservation_is_rejected_when_time_block_conflicts(): void
+    {
+        $admin = User::factory()->create([
+            'is_admin' => true,
+        ]);
+        $customer = User::factory()->create();
+
+        $menu = Menu::factory()->create([
+            'is_event' => false,
+            'duration' => 60,
+            'is_active' => true,
+        ]);
+
+        $date = now('Asia/Tokyo')->addDays(3)->startOfDay();
+        $this->createBusinessHour($date, '10:00:00', '20:00:00');
+
+        $start = $date->copy()->setTime(11, 0, 0);
+        $end = $date->copy()->setTime(12, 0, 0);
+
+        TimeBlock::create([
+            'start_at' => $date->copy()->setTime(10, 30, 0),
+            'end_at' => $date->copy()->setTime(12, 0, 0),
+            'reason' => '臨時対応',
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(ManageReservationCalendar::class)
+            ->set('directReservationUserId', $customer->id)
+            ->set('directReservationMenuId', $menu->id)
+            ->call('createDirectReservationFromCalendar', $start->toIso8601String(), $end->toIso8601String());
+
+        $this->assertDatabaseMissing('reservations', [
+            'user_id' => $customer->id,
+            'menu_id' => $menu->id,
+            'date' => $date->toDateString(),
+            'start_time' => '11:00:00',
+            'status' => 'confirmed',
+        ]);
+    }
+
+    public function test_admin_can_create_direct_event_reservation_and_reject_full_slot(): void
+    {
+        $admin = User::factory()->create([
+            'is_admin' => true,
+        ]);
+        $customer1 = User::factory()->create();
+        $customer2 = User::factory()->create();
+
+        $eventMenu = Menu::factory()->create([
+            'is_event' => true,
+            'duration' => 0,
+            'is_active' => true,
+        ]);
+
+        $date = now('Asia/Tokyo')->addDays(4)->startOfDay();
+        $slot = Slot::create([
+            'menu_id' => $eventMenu->id,
+            'date' => $date->toDateString(),
+            'start_time' => '14:00',
+            'end_time' => '15:00',
+            'capacity' => 1,
+            'is_reserved' => false,
+        ]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(ManageReservationCalendar::class)
+            ->set('directReservationUserId', $customer1->id)
+            ->set('directReservationMenuId', $eventMenu->id)
+            ->set('directReservationSlotId', $slot->id)
+            ->call(
+                'createDirectReservationFromCalendar',
+                $date->copy()->setTime(14, 0, 0)->toIso8601String(),
+                $date->copy()->setTime(15, 0, 0)->toIso8601String(),
+            );
+
+        $this->assertDatabaseHas('reservations', [
+            'user_id' => $customer1->id,
+            'menu_id' => $eventMenu->id,
+            'slot_id' => $slot->id,
+            'date' => $date->toDateString(),
+            'status' => 'confirmed',
+        ]);
+
+        Livewire::test(ManageReservationCalendar::class)
+            ->set('directReservationUserId', $customer2->id)
+            ->set('directReservationMenuId', $eventMenu->id)
+            ->set('directReservationSlotId', $slot->id)
+            ->call(
+                'createDirectReservationFromCalendar',
+                $date->copy()->setTime(14, 0, 0)->toIso8601String(),
+                $date->copy()->setTime(15, 0, 0)->toIso8601String(),
+            );
+
+        $this->assertSame(1, Reservation::query()->where('slot_id', $slot->id)->where('status', 'confirmed')->count());
+    }
+
+    private function createBusinessHour(Carbon $date, string $openTime, string $closeTime): void
+    {
+        BusinessHour::create([
+            'day_of_week' => null,
+            'specific_date' => $date->toDateString(),
+            'open_time' => $openTime,
+            'close_time' => $closeTime,
+            'is_closed' => false,
+        ]);
     }
 }


### PR DESCRIPTION
This pull request introduces a new "ダイレクト予約" (Direct Reservation) feature to the reservation calendar, allowing admins to create direct reservations by selecting time slots on the calendar. It adds a dedicated UI mode, modal dialogs for direct reservations, and comprehensive tests for the new functionality, including handling conflicts and event reservations.

**Direct Reservation Feature Implementation:**

* Added a new "ダイレクト予約" (Direct Reservation) operation mode button to the reservation calendar UI, allowing admins to switch modes and initiate direct reservations from the calendar.
* Implemented a modal dialog for confirming and creating direct reservations, including user, menu, option, and slot selection, with dynamic UI updates based on the selected menu type.
* Updated the calendar's selection handler to trigger the appropriate modal based on the current operation mode, supporting both block and direct reservation flows.
* Enhanced the operation mode description and styling to reflect the new direct reservation mode and provide clear instructions to users.

**Testing and Validation:**

* Added feature tests to ensure admins can create direct treatment and event reservations from the calendar, and that reservations are correctly rejected when conflicting with time blocks or full event slots. [[1]](diffhunk://#diff-816789a1ae5afd6e7076340c57e2a4ee5c85cf9c0dfacaa78af76d51090e3333R140-R297) [[2]](diffhunk://#diff-816789a1ae5afd6e7076340c57e2a4ee5c85cf9c0dfacaa78af76d51090e3333R6-R15)

**Other Improvements:**

* Updated the calendar toolbar to include previous/next navigation for improved usability.