### PR TITLE
ダイレクト予約ボタン色の修正、ウェルカムページ修正

### DIFF
--- a/src/app/Filament/Resources/WelcomePageSettingResource.php
+++ b/src/app/Filament/Resources/WelcomePageSettingResource.php
@@ -65,7 +65,7 @@ class WelcomePageSettingResource extends Resource
     {
         return [
             Forms\Components\Placeholder::make('welcome_mapping_guide')
-                ->hiddenLabel()
+                ->label('')
                 ->content(new HtmlString('<div class="space-y-2 text-sm">'
                     .'<div class="inline-flex items-center gap-2 rounded-full bg-sky-100 px-3 py-1 text-sky-900">① ヒーロー: バッジ/見出し/リード文/メイン画像</div>'
                     .'<div class="inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-emerald-900">② 本文セクション: 「本文セクション（文章・画像）」の各ブロック</div>'
@@ -75,7 +75,7 @@ class WelcomePageSettingResource extends Resource
                     .'</div>'))
                 ->columnSpanFull(),
             Forms\Components\Placeholder::make('welcome_group_hero')
-                ->hiddenLabel()
+                ->label('')
                 ->content(new HtmlString('<span class="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold text-sky-900">青色の項目はヒーロー領域（バッジ/見出し/リード文/メイン画像）に反映されます。</span>'))
                 ->columnSpanFull(),
             Forms\Components\TextInput::make('welcome_badge')
@@ -103,7 +103,7 @@ class WelcomePageSettingResource extends Resource
                 ->columnSpanFull()
                 ->live(onBlur: true),
             Forms\Components\Placeholder::make('welcome_group_design')
-                ->hiddenLabel()
+                ->label('')
                 ->content(new HtmlString('<span class="inline-flex items-center rounded-full bg-violet-100 px-3 py-1 text-xs font-semibold text-violet-900">紫色の項目はページ全体の背景とアクセントカラーに反映されます。</span>'))
                 ->columnSpanFull(),
             Forms\Components\Select::make('welcome_theme_background')
@@ -223,11 +223,11 @@ class WelcomePageSettingResource extends Resource
                 ->columnSpanFull()
                 ->live(),
             Forms\Components\Placeholder::make('welcome_group_body')
-                ->hiddenLabel()
+                ->label('')
                 ->content(new HtmlString('<span class="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-900">緑色の項目は本文セクションカード（見出し/本文/画像）に反映されます。</span>'))
                 ->columnSpanFull(),
             Forms\Components\Repeater::make('welcome_body_blocks')
-                ->hiddenLabel()
+                ->label('')
                 ->helperText('本文セクション（文章・画像）: お店のご案内エリアに反映されます。1件ならカード、複数ならスライド表示です。')
                 ->schema([
                     Forms\Components\TextInput::make('title')
@@ -311,7 +311,7 @@ class WelcomePageSettingResource extends Resource
                 ->collapsible()
                 ->columnSpanFull(),
             Forms\Components\Placeholder::make('welcome_group_shop')
-                ->hiddenLabel()
+                ->label('')
                 ->content(new HtmlString('<span class="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-900">橙色の項目は店舗情報カード（タイトル/紹介文/営業時間/補足）に反映されます。</span>'))
                 ->columnSpanFull(),
             Forms\Components\TextInput::make('welcome_shop_title')
@@ -411,7 +411,7 @@ class WelcomePageSettingResource extends Resource
                 ->columnSpanFull()
                 ->live(onBlur: true),
             Forms\Components\Placeholder::make('welcome_group_layout')
-                ->hiddenLabel()
+                ->label('')
                 ->content(new HtmlString('<span class="inline-flex items-center rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-900">灰色の項目はカード余白/角丸/影/フォントなど全体レイアウトに反映されます。</span>'))
                 ->columnSpanFull(),
             Forms\Components\Select::make('welcome_card_padding')

--- a/src/resources/views/filament/resources/reservation-resource/pages/manage-reservation-calendar.blade.php
+++ b/src/resources/views/filament/resources/reservation-resource/pages/manage-reservation-calendar.blade.php
@@ -44,48 +44,48 @@
                         wire:click="setOperationMode('reservation')"
                         class="inline-flex items-center gap-1.5 rounded-lg border px-4 py-2 text-sm font-semibold shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-offset-2
                             {{ $operationMode === 'reservation'
-                                ? 'border-sky-600 bg-sky-500 text-white shadow-sky-200 focus:ring-sky-400'
-                                : 'border-slate-300 bg-white text-slate-500 hover:border-sky-400 hover:bg-sky-50 hover:text-sky-700 focus:ring-sky-200' }}"
+                                ? 'border-sky-800 bg-sky-700 text-white shadow-sky-300 focus:ring-sky-500'
+                                : 'border-sky-200 bg-sky-50 text-sky-900 hover:border-sky-500 hover:bg-sky-100 focus:ring-sky-300' }}"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                         </svg>
                         予約を確認
-                        @if ($operationMode === 'reservation')
-                            <span class="ml-1 rounded-full bg-white/30 px-1.5 py-0.5 text-xs font-bold leading-none">ON</span>
-                        @endif
+                        <span class="ml-1 rounded-full px-2 py-0.5 text-xs font-bold leading-none {{ $operationMode === 'reservation' ? 'bg-white text-sky-800' : 'bg-sky-200 text-sky-800' }}">
+                            {{ $operationMode === 'reservation' ? 'ON' : 'OFF' }}
+                        </span>
                     </button>
                     <button
                         type="button"
                         wire:click="setOperationMode('block')"
                         class="inline-flex items-center gap-1.5 rounded-lg border px-4 py-2 text-sm font-semibold shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-offset-2
                             {{ $operationMode === 'block'
-                                ? 'border-red-600 bg-red-500 text-white shadow-red-200 focus:ring-red-400'
-                                : 'border-slate-300 bg-white text-slate-500 hover:border-red-400 hover:bg-red-50 hover:text-red-700 focus:ring-red-200' }}"
+                                ? 'border-rose-800 bg-rose-700 text-white shadow-rose-300 focus:ring-rose-500'
+                                : 'border-rose-200 bg-rose-50 text-rose-900 hover:border-rose-500 hover:bg-rose-100 focus:ring-rose-300' }}"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
                         </svg>
                         ブロックを作成
-                        @if ($operationMode === 'block')
-                            <span class="ml-1 rounded-full bg-white/30 px-1.5 py-0.5 text-xs font-bold leading-none">ON</span>
-                        @endif
+                        <span class="ml-1 rounded-full px-2 py-0.5 text-xs font-bold leading-none {{ $operationMode === 'block' ? 'bg-white text-rose-800' : 'bg-rose-200 text-rose-800' }}">
+                            {{ $operationMode === 'block' ? 'ON' : 'OFF' }}
+                        </span>
                     </button>
                     <button
                         type="button"
                         wire:click="setOperationMode('direct')"
                         class="inline-flex items-center gap-1.5 rounded-lg border px-4 py-2 text-sm font-semibold shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-offset-2
                             {{ $operationMode === 'direct'
-                                ? 'border-emerald-600 bg-emerald-500 text-white shadow-emerald-200 focus:ring-emerald-400'
-                                : 'border-slate-300 bg-white text-slate-500 hover:border-emerald-400 hover:bg-emerald-50 hover:text-emerald-700 focus:ring-emerald-200' }}"
+                                ? 'border-emerald-800 bg-emerald-700 text-white shadow-emerald-300 focus:ring-emerald-500'
+                                : 'border-emerald-200 bg-emerald-50 text-emerald-900 hover:border-emerald-500 hover:bg-emerald-100 focus:ring-emerald-300' }}"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10m-1 9H8a3 3 0 01-3-3V8a3 3 0 013-3h8a3 3 0 013 3v9a3 3 0 01-3 3z" />
                         </svg>
                         ダイレクト予約
-                        @if ($operationMode === 'direct')
-                            <span class="ml-1 rounded-full bg-white/30 px-1.5 py-0.5 text-xs font-bold leading-none">ON</span>
-                        @endif
+                        <span class="ml-1 rounded-full px-2 py-0.5 text-xs font-bold leading-none {{ $operationMode === 'direct' ? 'bg-white text-emerald-800' : 'bg-emerald-200 text-emerald-800' }}">
+                            {{ $operationMode === 'direct' ? 'ON' : 'OFF' }}
+                        </span>
                     </button>
                 </div>
 


### PR DESCRIPTION
This pull request makes UI improvements across two main areas: it standardizes the labeling of placeholders in the welcome page settings resource, and it enhances the appearance and clarity of the operation mode buttons in the reservation calendar management page.

**UI consistency and clarity improvements:**

* In `src/app/Filament/Resources/WelcomePageSettingResource.php`, all `Forms\Components\Placeholder` and relevant `Forms\Components\Repeater` components now use `->label('')` instead of `->hiddenLabel()`, ensuring a consistent approach to label handling for placeholders throughout the welcome page settings. [[1]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bL68-R68) [[2]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bL78-R78) [[3]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bL106-R106) [[4]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bL226-R230) [[5]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bL314-R314) [[6]](diffhunk://#diff-592adc6d157ae93518042070ff2f129825ac845616ffff4307b0f05b733e4d9bL414-R414)

**Reservation calendar UI enhancements:**

* In `src/resources/views/filament/resources/reservation-resource/pages/manage-reservation-calendar.blade.php`, updated the styling of the operation mode buttons to use more distinct and accessible color schemes for each mode, improving visual feedback for users.
* Replaced the conditional "ON" badge with a more informative badge that displays "ON" or "OFF" for each button, with styling that reflects the current state, making the active mode more visible and the UI more intuitive.