### PR TITLE
管理画面のCSS崩れ

### DIFF
--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -5,7 +5,6 @@ import forms from "@tailwindcss/forms";
 export default {
     content: [
         "./vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php",
-        "./vendor/filament/*/resources/**/*.blade.php",
         "./storage/framework/views/*.php",
         "./app/Filament/**/*.php",
         "./resources/views/**/*.blade.php",


### PR DESCRIPTION
This pull request makes a small update to the Tailwind CSS configuration by removing a file path from the `content` array. This change will prevent Tailwind from scanning the removed path for class names, which can help optimize the generated CSS.

- Removed the `./vendor/filament/*/resources/**/*.blade.php` path from the `content` array in `tailwind.config.js`, so Tailwind will no longer scan those files for utility classes.