### PR TITLE
管理画面のCSS崩れ　フィラメント標準化

### DIFF
--- a/src/app/Providers/Filament/AdminPanelProvider.php
+++ b/src/app/Providers/Filament/AdminPanelProvider.php
@@ -34,7 +34,6 @@ class AdminPanelProvider extends PanelProvider
             ->colors([
                 'primary' => Color::Amber,
             ])
-            ->viteTheme('resources/css/filament/admin/theme.css')
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->pages([

--- a/src/vite.config.js
+++ b/src/vite.config.js
@@ -6,7 +6,6 @@ export default defineConfig({
         laravel({
             input: [
                 "resources/css/app.css",
-                "resources/css/filament/admin/theme.css",
                 "resources/js/app.js",
                 "resources/js/business-hour-calendar.js",
             ],


### PR DESCRIPTION
This pull request makes a small update to the asset pipeline by removing the custom Filament admin theme CSS file from both the Filament panel configuration and the Vite build input. This means the `theme.css` file for the Filament admin panel is no longer being loaded or built.

- Asset pipeline cleanup:
  * Removed the `resources/css/filament/admin/theme.css` file from the Filament panel's theme configuration in `AdminPanelProvider.php`.
  * Removed the same CSS file from the Vite input array in `vite.config.js`, so it will no longer be processed by Vite.