### PR TITLE
Develop

### DIFF
--- a/src/app/Http/Controllers/Api/ReservationApiController.php
+++ b/src/app/Http/Controllers/Api/ReservationApiController.php
@@ -34,7 +34,7 @@ class ReservationApiController extends Controller
         }
 
         $query = Reservation::query()
-            ->with('menu')
+            ->with(['menu', 'options'])
             ->where('status', 'confirmed')
             ->where(function (Builder $subQuery): void {
                 $today = now('Asia/Tokyo')->toDateString();
@@ -62,7 +62,7 @@ class ReservationApiController extends Controller
                     'date_label' => $reservation->date?->locale('ja')->isoFormat('Y年M月D日(ddd)') ?? '日付未設定',
                     'time_label' => sprintf('%s - %s', $reservation->start_time?->format('H:i') ?? '--:--', $reservation->end_time?->format('H:i') ?? '--:--'),
                     'menu_name' => $reservation->menu?->name ?? 'メニュー未設定',
-                    'price_label' => '¥'.number_format((int) ($reservation->menu?->price ?? 0)),
+                    'price_label' => '¥'.number_format((int) ($reservation->menu?->price ?? 0) + (int) $reservation->options->sum('price')),
                     'cancel_url' => route('reservations.cancel', $reservation),
                     'api_cancel_url' => url('/api/reservations/'.$reservation->id),
                 ];
@@ -134,6 +134,18 @@ class ReservationApiController extends Controller
                         ]);
                     }
 
+                    $slotStartDateTime = Carbon::createFromFormat(
+                        'Y-m-d H:i',
+                        $slot->date->toDateString().' '.$slot->start_time->format('H:i'),
+                        'Asia/Tokyo'
+                    );
+
+                    if ($slotStartDateTime->lt(now('Asia/Tokyo'))) {
+                        throw ValidationException::withMessages([
+                            'start_time' => '当日のこの時間は選択できません。',
+                        ]);
+                    }
+
                     $confirmedCount = Reservation::query()
                         ->where('slot_id', $slot->id)
                         ->where('status', 'confirmed')
@@ -162,6 +174,13 @@ class ReservationApiController extends Controller
                         $validated['date'].' '.$validated['start_time'],
                         'Asia/Tokyo'
                     );
+
+                    if ($startDateTime->lt(now('Asia/Tokyo'))) {
+                        throw ValidationException::withMessages([
+                            'start_time' => '当日のこの時間は選択できません。',
+                        ]);
+                    }
+
                     $endDateTime = $startDateTime->clone()->addMinutes($menu->duration + $options->sum('duration'));
 
                     Reservation::where('date', $startDateTime->toDateString())

--- a/src/app/Http/Controllers/MypageController.php
+++ b/src/app/Http/Controllers/MypageController.php
@@ -20,7 +20,7 @@ class MypageController extends Controller
 
         $reservations = $user
             ->reservations()
-            ->with(['menu', 'slot'])
+            ->with(['menu', 'slot', 'options'])
             ->whereDate('date', '>=', now()->toDateString())
             ->where('status', 'confirmed')
             ->orderBy('date')

--- a/src/app/Http/Controllers/ReservationController.php
+++ b/src/app/Http/Controllers/ReservationController.php
@@ -174,6 +174,76 @@ class ReservationController extends Controller
     }
 
     /**
+     * 当日専用: 時間選択画面
+     */
+    public function sameDayTimes()
+    {
+        $today = now('Asia/Tokyo')->startOfDay();
+        $date = $today->toDateString();
+
+        if (! $this->isDateReservableForUsers($date)) {
+            return view('reservations.same-day-times', [
+                'date' => $today,
+                'availableTimes' => [],
+                'availabilityReason' => self::MONTH_UNPUBLISHED_REASON,
+            ]);
+        }
+
+        $availableTimes = $this->getSameDayAvailableTimes($date);
+
+        return view('reservations.same-day-times', [
+            'date' => $today,
+            'availableTimes' => $availableTimes,
+            'availabilityReason' => empty($availableTimes) ? 'fully_booked' : 'available',
+        ]);
+    }
+
+    /**
+     * 当日専用: メニュー選択画面
+     */
+    public function sameDayMenus(Request $request)
+    {
+        $validated = $request->validate([
+            'start_time' => 'required|date_format:H:i',
+        ]);
+
+        $today = now('Asia/Tokyo')->startOfDay();
+        $date = $today->toDateString();
+        $startTime = $validated['start_time'];
+
+        if (! $this->isDateReservableForUsers($date)) {
+            return redirect()->route('reservations.same-day.times')
+                ->with('availability_reason', self::MONTH_UNPUBLISHED_REASON);
+        }
+
+        $startDateTime = Carbon::createFromFormat('Y-m-d H:i', $date.' '.$startTime, 'Asia/Tokyo');
+        if ($startDateTime->lt(now('Asia/Tokyo'))) {
+            return redirect()->route('reservations.same-day.times')
+                ->withErrors(['start_time' => '当日のこの時間は選択できません。']);
+        }
+
+        $availabilityService = new AvailabilityService;
+        $menus = Menu::query()
+            ->treatments()
+            ->where('is_active', true)
+            ->with(['options' => fn ($query) => $query->active()])
+            ->orderedForDisplay()
+            ->get()
+            ->filter(function (Menu $menu) use ($availabilityService, $date, $startTime): bool {
+                $availableTimes = $availabilityService->getAvailableTimes($menu, [], $date);
+
+                return in_array($startTime, $availableTimes, true);
+            })
+            ->values();
+
+        return view('reservations.same-day-menus', [
+            'date' => $today,
+            'startTime' => $startTime,
+            'menus' => $menus,
+        ]);
+    }
+
+    /**
      * 予約確認画面
      */
     public function confirm(Request $request)
@@ -360,6 +430,18 @@ class ReservationController extends Controller
                         ]);
                     }
 
+                    $slotStartDateTime = Carbon::createFromFormat(
+                        'Y-m-d H:i',
+                        $slot->date->toDateString().' '.$slot->start_time->format('H:i'),
+                        'Asia/Tokyo'
+                    );
+
+                    if ($slotStartDateTime->lt(now('Asia/Tokyo'))) {
+                        throw ValidationException::withMessages([
+                            'start_time' => '当日のこの時間は選択できません。',
+                        ]);
+                    }
+
                     $confirmedCount = Reservation::query()
                         ->where('slot_id', $slot->id)
                         ->where('status', 'confirmed')
@@ -388,6 +470,12 @@ class ReservationController extends Controller
                         "$date $startTime",
                         'Asia/Tokyo'
                     );
+
+                    if ($startDateTime->lt(now('Asia/Tokyo'))) {
+                        throw ValidationException::withMessages([
+                            'start_time' => '当日のこの時間は選択できません。',
+                        ]);
+                    }
 
                     $totalDuration = $menu->duration;
                     foreach ($options as $option) {
@@ -495,5 +583,29 @@ class ReservationController extends Controller
         }
 
         return MenuOption::whereIn('id', $optionIds)->where('menu_id', $menu->id)->active()->get();
+    }
+
+    private function getSameDayAvailableTimes(string $date): array
+    {
+        $availabilityService = new AvailabilityService;
+        $menus = Menu::query()
+            ->treatments()
+            ->where('is_active', true)
+            ->orderedForDisplay()
+            ->get();
+
+        $timeMap = [];
+
+        foreach ($menus as $menu) {
+            $times = $availabilityService->getAvailableTimes($menu, [], $date);
+            foreach ($times as $time) {
+                $timeMap[$time] = true;
+            }
+        }
+
+        $availableTimes = array_keys($timeMap);
+        sort($availableTimes);
+
+        return $availableTimes;
     }
 }

--- a/src/app/Services/AvailabilityService.php
+++ b/src/app/Services/AvailabilityService.php
@@ -80,6 +80,8 @@ class AvailabilityService
     public function getAvailableTimesWithReason(Menu $menu, array $optionIds, string $date): array
     {
         $dateCarbon = Carbon::createFromFormat('Y-m-d', $date)->startOfDay();
+        $nowTokyo = now('Asia/Tokyo');
+        $isSameDayAsNow = $dateCarbon->isSameDay($nowTokyo);
         $businessSetting = BusinessHour::getSettingForDate($dateCarbon);
 
         if (! $businessSetting) {
@@ -119,6 +121,11 @@ class AvailabilityService
                 $dateCarbon->toDateString().' '.$candidate,
                 'Asia/Tokyo'
             );
+
+            if ($isSameDayAsNow && $startDateTime->lt($nowTokyo)) {
+                continue;
+            }
+
             $endDateTime = $startDateTime->clone()->addMinutes($totalDuration);
 
             $conflict = $this->hasConflict($startDateTime, $endDateTime, $reservedRanges);
@@ -210,6 +217,9 @@ class AvailabilityService
 
     private function getEventAvailableTimesWithReason(Menu $menu, Carbon $dateCarbon): array
     {
+        $nowTokyo = now('Asia/Tokyo');
+        $isSameDayAsNow = $dateCarbon->isSameDay($nowTokyo);
+
         $slots = Slot::query()
             ->with('menu')
             ->withCount([
@@ -238,6 +248,15 @@ class AvailabilityService
 
         foreach ($slots as $slot) {
             $time = $slot->start_time->format('H:i');
+            $slotStartDateTime = Carbon::createFromFormat(
+                'Y-m-d H:i',
+                $dateCarbon->toDateString().' '.$time,
+                'Asia/Tokyo'
+            );
+
+            if ($isSameDayAsNow && $slotStartDateTime->lt($nowTokyo)) {
+                continue;
+            }
 
             if ($userAlreadyReserved) {
                 $status = 'user_already_reserved';

--- a/src/resources/views/filament/resources/business-hour-resource/pages/list-business-hours.blade.php
+++ b/src/resources/views/filament/resources/business-hour-resource/pages/list-business-hours.blade.php
@@ -141,7 +141,7 @@
                             <td class="px-4 py-2.5">
                                 <span class="font-mono text-slate-800">{{ $date->format('m/d') }}</span>
                                 @if($isToday)
-                                    <span class="ml-1.5 rounded bg-sky-500 px-1.5 py-0.5 text-xs font-bold text-white">今日の予約</span>
+                                    <span class="ml-1.5 rounded bg-sky-500 px-1.5 py-0.5 text-xs font-bold text-white">今日予約する</span>
                                 @endif
                             </td>
                             <td class="px-3 py-2.5 font-semibold

--- a/src/resources/views/filament/resources/business-hour-resource/pages/list-business-hours.blade.php
+++ b/src/resources/views/filament/resources/business-hour-resource/pages/list-business-hours.blade.php
@@ -141,7 +141,7 @@
                             <td class="px-4 py-2.5">
                                 <span class="font-mono text-slate-800">{{ $date->format('m/d') }}</span>
                                 @if($isToday)
-                                    <span class="ml-1.5 rounded bg-sky-500 px-1.5 py-0.5 text-xs font-bold text-white">今日</span>
+                                    <span class="ml-1.5 rounded bg-sky-500 px-1.5 py-0.5 text-xs font-bold text-white">今日の予約</span>
                                 @endif
                             </td>
                             <td class="px-3 py-2.5 font-semibold

--- a/src/resources/views/layouts/navigation.blade.php
+++ b/src/resources/views/layouts/navigation.blade.php
@@ -25,6 +25,11 @@
                         メニューを見る
                     </a>
                     @auth
+                        <a href="{{ route('reservations.same-day.times') }}"
+                           class="px-3 py-2 rounded-lg text-sm font-semibold text-sky-800 hover:text-white hover:bg-gradient-to-r hover:from-emerald-400 hover:to-teal-500 transition shadow-sm"
+                           aria-label="今日の予約">
+                            今日の予約
+                        </a>
                         <a href="{{ route('mypage') }}"
                            class="px-3 py-2 rounded-lg text-sm font-semibold text-sky-800 hover:text-white hover:bg-gradient-to-r hover:from-sky-400 hover:to-blue-500 transition shadow-sm"
                            aria-label="マイページ">
@@ -107,7 +112,7 @@
             </div>
         </div>
 
-        <div class="grid grid-cols-3 gap-2 pb-2 sm:hidden">
+        <div class="grid {{ $currentUser ? 'grid-cols-4' : 'grid-cols-3' }} gap-2 pb-2 sm:hidden">
             <a href="{{ route('menus.index') }}"
                class="inline-flex items-center justify-center rounded-lg px-3 py-2 text-[13px] font-semibold shadow-sm
                       transition-all duration-150 ease-out
@@ -116,9 +121,19 @@
                           ? 'bg-sky-600 text-white shadow-sky-300 shadow-md'
                           : 'bg-white/80 text-sky-800 ring-1 ring-sky-200' }}"
                aria-label="メニュー">
-                サービス
+                メニュー
             </a>
             @auth
+                <a href="{{ route('reservations.same-day.times') }}"
+                   class="inline-flex items-center justify-center rounded-lg px-3 py-2 text-[13px] font-semibold shadow-sm
+                          transition-all duration-150 ease-out
+                          active:scale-95 active:brightness-90
+                          {{ request()->routeIs('reservations.same-day.*')
+                              ? 'bg-emerald-600 text-white shadow-emerald-300 shadow-md'
+                              : 'bg-white/80 text-sky-800 ring-1 ring-sky-200' }}"
+                   aria-label="今日の予約">
+                    今日の予約
+                </a>
                 <a href="{{ route('mypage') }}"
                    class="inline-flex items-center justify-center rounded-lg px-3 py-2 text-[13px] font-semibold shadow-sm
                           transition-all duration-150 ease-out
@@ -163,6 +178,10 @@
             <div class="pt-2 pb-3 space-y-1">
                 <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                     {{ __('お知らせ') }}
+                </x-responsive-nav-link>
+
+                <x-responsive-nav-link :href="route('reservations.same-day.times')" :active="request()->routeIs('reservations.same-day.*')">
+                    {{ __('今日の予約') }}
                 </x-responsive-nav-link>
 
                 @if($isAdmin)

--- a/src/resources/views/layouts/navigation.blade.php
+++ b/src/resources/views/layouts/navigation.blade.php
@@ -27,8 +27,8 @@
                     @auth
                         <a href="{{ route('reservations.same-day.times') }}"
                            class="px-3 py-2 rounded-lg text-sm font-semibold text-sky-800 hover:text-white hover:bg-gradient-to-r hover:from-emerald-400 hover:to-teal-500 transition shadow-sm"
-                           aria-label="今日の予約">
-                            今日の予約
+                           aria-label="今日予約する">
+                            今日予約する
                         </a>
                         <a href="{{ route('mypage') }}"
                            class="px-3 py-2 rounded-lg text-sm font-semibold text-sky-800 hover:text-white hover:bg-gradient-to-r hover:from-sky-400 hover:to-blue-500 transition shadow-sm"
@@ -131,8 +131,8 @@
                           {{ request()->routeIs('reservations.same-day.*')
                               ? 'bg-emerald-600 text-white shadow-emerald-300 shadow-md'
                               : 'bg-white/80 text-sky-800 ring-1 ring-sky-200' }}"
-                   aria-label="今日の予約">
-                    今日の予約
+                   aria-label="今日予約する">
+                    今日予約する
                 </a>
                 <a href="{{ route('mypage') }}"
                    class="inline-flex items-center justify-center rounded-lg px-3 py-2 text-[13px] font-semibold shadow-sm
@@ -181,7 +181,7 @@
                 </x-responsive-nav-link>
 
                 <x-responsive-nav-link :href="route('reservations.same-day.times')" :active="request()->routeIs('reservations.same-day.*')">
-                    {{ __('今日の予約') }}
+                    {{ __('今日予約する') }}
                 </x-responsive-nav-link>
 
                 @if($isAdmin)

--- a/src/resources/views/menus/show.blade.php
+++ b/src/resources/views/menus/show.blade.php
@@ -147,6 +147,12 @@
                                     class="flex-1 text-center px-6 py-3.5 rounded-xl bg-sky-500 text-white font-semibold shadow-sm hover:bg-sky-600 focus:outline-none focus:ring-2 focus:ring-sky-300 focus:ring-offset-2 transition">
                                 {{ $menu->is_event ? 'イベント日時を選択する' : '日時を選択して予約へ進む' }}
                             </button>
+                            @if(! $menu->is_event)
+                                <a href="{{ route('reservations.same-day.times') }}"
+                                   class="px-5 py-3.5 rounded-xl bg-emerald-50 text-emerald-800 font-semibold border border-emerald-200 hover:bg-emerald-100 transition whitespace-nowrap">
+                                    今日の予約
+                                </a>
+                            @endif
                             <a href="{{ route('menus.index') }}"
                                class="px-5 py-3.5 rounded-xl bg-sky-50 text-sky-800 font-semibold border border-sky-200 hover:bg-sky-100 transition">
                                 戻る
@@ -162,6 +168,12 @@
                                     class="w-full text-center px-6 py-3.5 rounded-xl bg-sky-500 text-white font-semibold shadow-sm active:scale-[0.99] hover:bg-sky-600 focus:outline-none focus:ring-2 focus:ring-sky-300 transition">
                                 {{ $menu->is_event ? 'イベント日時を選択する' : '日時を選択して予約へ進む' }}
                             </button>
+                            @if(! $menu->is_event)
+                                <a href="{{ route('reservations.same-day.times') }}"
+                                   class="mt-2 block w-full rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-center text-sm font-semibold text-emerald-800 transition hover:bg-emerald-100">
+                                    今日の予約
+                                </a>
+                            @endif
                         </div>
                     </form>
                 </div>

--- a/src/resources/views/menus/show.blade.php
+++ b/src/resources/views/menus/show.blade.php
@@ -150,7 +150,7 @@
                             @if(! $menu->is_event)
                                 <a href="{{ route('reservations.same-day.times') }}"
                                    class="px-5 py-3.5 rounded-xl bg-emerald-50 text-emerald-800 font-semibold border border-emerald-200 hover:bg-emerald-100 transition whitespace-nowrap">
-                                    今日の予約
+                                    今日予約する
                                 </a>
                             @endif
                             <a href="{{ route('menus.index') }}"
@@ -171,7 +171,7 @@
                             @if(! $menu->is_event)
                                 <a href="{{ route('reservations.same-day.times') }}"
                                    class="mt-2 block w-full rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-center text-sm font-semibold text-emerald-800 transition hover:bg-emerald-100">
-                                    今日の予約
+                                    今日予約する
                                 </a>
                             @endif
                         </div>

--- a/src/resources/views/mypage.blade.php
+++ b/src/resources/views/mypage.blade.php
@@ -34,7 +34,7 @@
                         'time_label' => $reservation->start_time->format('H:i').' - '.$reservation->end_time->format('H:i'),
                         'menu_name' => $reservation->menu->name,
                         'is_event' => (bool) $reservation->menu->is_event,
-                        'price_label' => '¥'.number_format($reservation->menu->price),
+                        'price_label' => '¥'.number_format((int) ($reservation->menu->price ?? 0) + (int) $reservation->options->sum('price')),
                         'cancel_url' => route('reservations.cancel', $reservation),
                         'api_cancel_url' => url('/api/reservations/'.$reservation->id),
                     ];

--- a/src/resources/views/reservations/calendar.blade.php
+++ b/src/resources/views/reservations/calendar.blade.php
@@ -72,10 +72,11 @@
 
                     $start = $month->clone()->startOfMonth()->startOfWeek();
                     $end = $month->clone()->endOfMonth()->endOfWeek();
+                    $today = now('Asia/Tokyo')->startOfDay();
                     $availableDateList = [];
                     for ($d = $start->copy(); $d < $end; $d->addDay()) {
                         $key = $d->toDateString();
-                        if (($availableDates[$key] ?? false) && ! $d->isPast()) {
+                        if (($availableDates[$key] ?? false) && $d->gte($today)) {
                             $availableDateList[] = $d->copy();
                         }
                     }

--- a/src/resources/views/reservations/complete.blade.php
+++ b/src/resources/views/reservations/complete.blade.php
@@ -57,7 +57,10 @@
                         
                         <div class="border-b pb-4">
                             <h3 class="text-sm text-gray-500 mb-1">料金</h3>
-                            <p class="text-2xl font-bold text-blue-600">¥{{ number_format($reservation->menu->price) }}</p>
+                            @php
+                                $totalPrice = (int) ($reservation->menu->price ?? 0) + (int) $reservation->options->sum('price');
+                            @endphp
+                            <p class="text-2xl font-bold text-blue-600">¥{{ number_format($totalPrice) }}</p>
                         </div>
                         
                         <div class="pb-4">

--- a/src/resources/views/reservations/same-day-menus.blade.php
+++ b/src/resources/views/reservations/same-day-menus.blade.php
@@ -1,0 +1,89 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-slate-800 leading-tight">
+            今日の予約
+        </h2>
+    </x-slot>
+
+    <div class="py-6 sm:py-10">
+        <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+            <div class="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-slate-200 sm:p-7">
+                <div class="mb-6 rounded-2xl bg-gradient-to-r from-cyan-50 to-sky-50 p-4 ring-1 ring-cyan-100 sm:p-5">
+                    <p class="text-xs font-semibold tracking-wide text-cyan-700">SAME DAY RESERVATION</p>
+                    <h1 class="mt-1 text-xl font-bold text-slate-900 sm:text-2xl">{{ $date->isoFormat('Y年M月D日(ddd)') }} {{ $startTime }} スタート</h1>
+                    <p class="mt-2 text-sm text-slate-600">この時間で予約可能な通常メニューを表示しています。オプションを選択して確認へ進んでください。</p>
+                </div>
+
+                @if($menus->isEmpty())
+                    <div class="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+                        この時間で予約可能な通常メニューはありません。別の時間をお試しください。
+                    </div>
+                @else
+                    <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                        @foreach($menus as $menu)
+                            <article class="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-slate-200">
+                                <div class="relative aspect-[4/3] w-full overflow-hidden">
+                                    @if($menu->image_path)
+                                        <img src="{{ Storage::url($menu->image_path) }}" alt="{{ $menu->name }}" class="h-full w-full object-cover">
+                                    @else
+                                        <div class="flex h-full w-full items-center justify-center bg-slate-100">
+                                            <span class="text-sm text-slate-400">画像なし</span>
+                                        </div>
+                                    @endif
+                                </div>
+
+                                <div class="p-4 sm:p-5">
+                                    <h2 class="text-lg font-bold text-slate-900">{{ $menu->name }}</h2>
+                                    <p class="mt-2 text-sm text-slate-600">{{ \Illuminate\Support\Str::limit((string) $menu->description, 86) }}</p>
+
+                                    <div class="mt-3 grid grid-cols-2 gap-2 text-sm">
+                                        <div class="rounded-lg bg-cyan-50 px-3 py-2 text-cyan-800">
+                                            <p class="text-[11px] font-semibold">料金</p>
+                                            <p class="font-bold">¥{{ number_format($menu->price) }}</p>
+                                        </div>
+                                        <div class="rounded-lg bg-slate-50 px-3 py-2 text-slate-800">
+                                            <p class="text-[11px] font-semibold">所要時間</p>
+                                            <p class="font-bold">{{ $menu->duration }}分</p>
+                                        </div>
+                                    </div>
+
+                                    <form method="GET" action="{{ route('reservations.confirm') }}" class="mt-4 space-y-3">
+                                        <input type="hidden" name="menu_id" value="{{ $menu->id }}">
+                                        <input type="hidden" name="date" value="{{ $date->toDateString() }}">
+                                        <input type="hidden" name="start_time" value="{{ $startTime }}">
+
+                                        @if($menu->options->isNotEmpty())
+                                            <div class="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                                                <p class="mb-2 text-xs font-semibold text-slate-700">オプションを選択</p>
+                                                <div class="space-y-2">
+                                                    @foreach($menu->options as $option)
+                                                        <label class="flex items-center justify-between gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
+                                                            <span>{{ $option->name }}</span>
+                                                            <span class="text-xs text-slate-500">+¥{{ number_format($option->price) }} / +{{ $option->duration }}分</span>
+                                                            <input type="checkbox" name="options[]" value="{{ $option->id }}" class="h-4 w-4 rounded border-slate-300 text-sky-600 focus:ring-sky-500">
+                                                        </label>
+                                                    @endforeach
+                                                </div>
+                                            </div>
+                                        @endif
+
+                                        <button type="submit"
+                                                class="w-full rounded-xl bg-sky-500 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-600 focus:outline-none focus:ring-2 focus:ring-sky-300 focus:ring-offset-2">
+                                            このメニューで確認へ進む
+                                        </button>
+                                    </form>
+                                </div>
+                            </article>
+                        @endforeach
+                    </div>
+                @endif
+
+                <div class="mt-6">
+                    <a href="{{ route('reservations.same-day.times') }}" class="text-sm font-semibold text-slate-600 transition hover:text-slate-900">
+                        ← 時間選択に戻る
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/src/resources/views/reservations/same-day-menus.blade.php
+++ b/src/resources/views/reservations/same-day-menus.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-slate-800 leading-tight">
-            今日の予約
+            今日予約する
         </h2>
     </x-slot>
 

--- a/src/resources/views/reservations/same-day-times.blade.php
+++ b/src/resources/views/reservations/same-day-times.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-slate-800 leading-tight">
-            今日の予約
+            今日予約する
         </h2>
     </x-slot>
 

--- a/src/resources/views/reservations/same-day-times.blade.php
+++ b/src/resources/views/reservations/same-day-times.blade.php
@@ -1,0 +1,63 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-slate-800 leading-tight">
+            今日の予約
+        </h2>
+    </x-slot>
+
+    <div class="py-6 sm:py-10">
+        <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+            <div class="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-slate-200 sm:p-7">
+                <div class="mb-6 rounded-2xl bg-gradient-to-r from-cyan-50 to-sky-50 p-4 ring-1 ring-cyan-100 sm:p-5">
+                    <p class="text-xs font-semibold tracking-wide text-cyan-700">SAME DAY RESERVATION</p>
+                    <h1 class="mt-1 text-xl font-bold text-slate-900 sm:text-2xl">{{ $date->isoFormat('Y年M月D日(ddd)') }}</h1>
+                    <p class="mt-2 text-sm text-slate-600">空いている時間を選択すると、次の画面でメニューとオプションを選べます。</p>
+                </div>
+
+                @if($errors->has('start_time'))
+                    <div class="mb-4 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+                        {{ $errors->first('start_time') }}
+                    </div>
+                @endif
+
+                @php
+                    $reasonMessages = [
+                        'month_unpublished' => '当月の予約枠が現在非公開です。管理者の公開設定後にご利用ください。',
+                        'fully_booked' => '本日ご案内できる時間がありません。お手数ですが通常予約から別日をご確認ください。',
+                    ];
+                @endphp
+
+                @if(empty($availableTimes))
+                    <div class="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+                        {{ $reasonMessages[$availabilityReason] ?? '本日ご案内できる時間がありません。' }}
+                    </div>
+                @else
+                    <form method="GET" action="{{ route('reservations.same-day.menus') }}" class="space-y-5">
+                        <div>
+                            <h2 class="text-base font-bold text-slate-900 sm:text-lg">時間を選択してください</h2>
+                            <p class="mt-1 text-xs text-slate-500">この時間に予約可能な通常メニューのみ、次の画面で表示されます。</p>
+                        </div>
+
+                        <div class="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                            @foreach($availableTimes as $time)
+                                <button type="submit"
+                                        name="start_time"
+                                        value="{{ $time }}"
+                                        class="rounded-xl border border-sky-300 bg-sky-50 px-3 py-3 text-center transition hover:border-sky-500 hover:bg-sky-100 active:scale-[0.99]">
+                                    <span class="block text-lg font-bold text-slate-900">{{ $time }}</span>
+                                    <span class="block text-[11px] text-slate-500">この時間で探す</span>
+                                </button>
+                            @endforeach
+                        </div>
+                    </form>
+                @endif
+
+                <div class="mt-6">
+                    <a href="{{ route('menus.index') }}" class="text-sm font-semibold text-slate-600 transition hover:text-slate-900">
+                        ← メニュー一覧へ戻る
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -30,6 +30,8 @@ Route::middleware('auth')->group(function () {
 
     Route::get('/reservations/calendar', [ReservationController::class, 'calendar'])->name('reservations.calendar');
     Route::get('/reservations/times', [ReservationController::class, 'times'])->name('reservations.times');
+    Route::get('/reservations/same-day/times', [ReservationController::class, 'sameDayTimes'])->name('reservations.same-day.times');
+    Route::get('/reservations/same-day/menus', [ReservationController::class, 'sameDayMenus'])->name('reservations.same-day.menus');
     Route::get('/reservations/confirm', [ReservationController::class, 'confirm'])->name('reservations.confirm');
     Route::post('/reservations', [ReservationController::class, 'store'])->name('reservations.store');
     Route::get('/reservations/{reservation}/complete', [ReservationController::class, 'complete'])->name('reservations.complete');

--- a/src/tests/Feature/ReservationCalendarTest.php
+++ b/src/tests/Feature/ReservationCalendarTest.php
@@ -270,4 +270,30 @@ class ReservationCalendarTest extends TestCase
 
         Carbon::setTestNow();
     }
+
+    public function test_calendar_includes_today_when_available(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 8, 9, 0, 0, 'Asia/Tokyo'));
+
+        try {
+            ReservationPublicationMonth::updateOrCreate([
+                'year_month' => '2026-06',
+            ], [
+                'is_published' => true,
+            ]);
+
+            $menu = Menu::factory()->create();
+            $user = User::factory()->create();
+
+            $response = $this->actingAs($user)->get(route('reservations.calendar', [
+                'menu_id' => $menu->id,
+                'month' => '2026-06',
+            ]));
+
+            $response->assertOk();
+            $response->assertSee('value="2026-06-08"', false);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
 }

--- a/src/tests/Feature/ReservationOverlapTest.php
+++ b/src/tests/Feature/ReservationOverlapTest.php
@@ -8,6 +8,7 @@ use App\Models\Reservation;
 use App\Models\ReservationPublicationMonth;
 use App\Models\User;
 use App\Services\AvailabilityService;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
@@ -179,5 +180,88 @@ class ReservationOverlapTest extends TestCase
         $mypageResponse->assertOk();
         $mypageResponse->assertSee('カットカラー');
         $mypageResponse->assertSee('11:00 - 12:00');
+    }
+
+    public function test_availability_excludes_past_times_on_same_day(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 8, 15, 10, 0, 'Asia/Tokyo'));
+
+        try {
+            ReservationPublicationMonth::updateOrCreate([
+                'year_month' => '2026-06',
+            ], [
+                'is_published' => true,
+            ]);
+
+            $menu = Menu::factory()->create(['duration' => 60]);
+
+            $availableTimes = (new AvailabilityService)->getAvailableTimes($menu, [], '2026-06-08');
+
+            $this->assertNotContains('15:00', $availableTimes);
+            $this->assertContains('15:30', $availableTimes);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_web_store_rejects_past_time_on_same_day(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 8, 10, 10, 0, 'Asia/Tokyo'));
+
+        try {
+            ReservationPublicationMonth::updateOrCreate([
+                'year_month' => '2026-06',
+            ], [
+                'is_published' => true,
+            ]);
+
+            $menu = Menu::factory()->create(['duration' => 60]);
+            $user = User::factory()->create();
+
+            $response = $this->actingAs($user)->post('/reservations', [
+                'menu_id' => $menu->id,
+                'date' => '2026-06-08',
+                'start_time' => '10:00',
+                'options' => [],
+            ]);
+
+            $response->assertStatus(302);
+            $response->assertSessionHasErrors('start_time');
+            $this->assertDatabaseCount('reservations', 0);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_api_store_rejects_past_time_on_same_day(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 8, 10, 10, 0, 'Asia/Tokyo'));
+
+        try {
+            ReservationPublicationMonth::updateOrCreate([
+                'year_month' => '2026-06',
+            ], [
+                'is_published' => true,
+            ]);
+
+            $menu = Menu::factory()->create(['duration' => 60]);
+            $user = User::factory()->create();
+
+            $response = $this->actingAs($user)->postJson('/api/reservations', [
+                'menu_id' => $menu->id,
+                'date' => '2026-06-08',
+                'start_time' => '10:00',
+                'options' => [],
+            ]);
+
+            $response->assertStatus(422);
+            $response->assertJson([
+                'success' => false,
+                'message' => '当日のこの時間は選択できません。',
+            ]);
+            $this->assertDatabaseCount('reservations', 0);
+        } finally {
+            Carbon::setTestNow();
+        }
     }
 }

--- a/src/tests/Feature/SameDayReservationFlowTest.php
+++ b/src/tests/Feature/SameDayReservationFlowTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\BusinessHour;
+use App\Models\Menu;
+use App\Models\ReservationPublicationMonth;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SameDayReservationFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        for ($day = 0; $day < 7; $day++) {
+            BusinessHour::create([
+                'day_of_week' => $day,
+                'open_time' => '10:00',
+                'close_time' => '20:00',
+                'is_closed' => false,
+            ]);
+        }
+
+        ReservationPublicationMonth::updateOrCreate([
+            'year_month' => now('Asia/Tokyo')->format('Y-m'),
+        ], [
+            'is_published' => true,
+        ]);
+    }
+
+    public function test_same_day_times_page_requires_authentication(): void
+    {
+        $response = $this->get(route('reservations.same-day.times'));
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_same_day_times_page_shows_available_time_buttons(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 8, 9, 0, 0, 'Asia/Tokyo'));
+
+        try {
+            ReservationPublicationMonth::updateOrCreate([
+                'year_month' => '2026-06',
+            ], [
+                'is_published' => true,
+            ]);
+
+            Menu::factory()->create([
+                'is_event' => false,
+                'is_active' => true,
+                'duration' => 60,
+            ]);
+
+            $user = User::factory()->create();
+
+            $response = $this->actingAs($user)->get(route('reservations.same-day.times'));
+
+            $response->assertOk();
+            $response->assertSee('今日の予約');
+            $response->assertSee('value="10:00"', false);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_same_day_menus_filters_unavailable_long_duration_menu(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 8, 9, 0, 0, 'Asia/Tokyo'));
+
+        try {
+            ReservationPublicationMonth::updateOrCreate([
+                'year_month' => '2026-06',
+            ], [
+                'is_published' => true,
+            ]);
+
+            BusinessHour::query()->delete();
+            for ($day = 0; $day < 7; $day++) {
+                BusinessHour::create([
+                    'day_of_week' => $day,
+                    'open_time' => '10:00',
+                    'close_time' => '11:00',
+                    'is_closed' => false,
+                ]);
+            }
+
+            $shortMenu = Menu::factory()->create([
+                'name' => 'ショートメニュー',
+                'is_event' => false,
+                'is_active' => true,
+                'duration' => 30,
+            ]);
+
+            $longMenu = Menu::factory()->create([
+                'name' => 'ロングメニュー',
+                'is_event' => false,
+                'is_active' => true,
+                'duration' => 90,
+            ]);
+
+            $user = User::factory()->create();
+
+            $response = $this->actingAs($user)->get(route('reservations.same-day.menus', [
+                'start_time' => '10:30',
+            ]));
+
+            $response->assertOk();
+            $response->assertSee($shortMenu->name);
+            $response->assertDontSee($longMenu->name);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_same_day_menus_rejects_past_time_selection(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 8, 10, 10, 0, 'Asia/Tokyo'));
+
+        try {
+            ReservationPublicationMonth::updateOrCreate([
+                'year_month' => '2026-06',
+            ], [
+                'is_published' => true,
+            ]);
+
+            Menu::factory()->create([
+                'is_event' => false,
+                'is_active' => true,
+                'duration' => 60,
+            ]);
+
+            $user = User::factory()->create();
+
+            $response = $this->actingAs($user)->get(route('reservations.same-day.menus', [
+                'start_time' => '10:00',
+            ]));
+
+            $response->assertRedirect(route('reservations.same-day.times'));
+            $response->assertSessionHasErrors('start_time');
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+}

--- a/src/tests/Feature/SameDayReservationFlowTest.php
+++ b/src/tests/Feature/SameDayReservationFlowTest.php
@@ -63,7 +63,7 @@ class SameDayReservationFlowTest extends TestCase
             $response = $this->actingAs($user)->get(route('reservations.same-day.times'));
 
             $response->assertOk();
-            $response->assertSee('今日の予約');
+            $response->assertSee('今日予約する');
             $response->assertSee('value="10:00"', false);
         } finally {
             Carbon::setTestNow();


### PR DESCRIPTION
This pull request introduces a "same-day reservation" feature, enhances reservation validation for same-day bookings, and ensures that reservation prices include selected options. It also updates the UI to make the new feature prominent and improves how available dates and prices are displayed.

**Same-Day Reservation Feature:**

- Added new controller methods (`sameDayTimes`, `sameDayMenus`) and supporting logic to allow users to view and book available times and menus specifically for same-day reservations. These are accessible via new UI links and navigation buttons. [[1]](diffhunk://#diff-e0ad572482f64a053e1d69295cfb1e7c2b0d704d62218543f56fb151474cdf85R176-R245) [[2]](diffhunk://#diff-e5e1e5e42fecc4ac6302da87724d37a7c9330d33ad2878c954f305bb771b06d0R28-R32) [[3]](diffhunk://#diff-e5e1e5e42fecc4ac6302da87724d37a7c9330d33ad2878c954f305bb771b06d0L110-R115) [[4]](diffhunk://#diff-e5e1e5e42fecc4ac6302da87724d37a7c9330d33ad2878c954f305bb771b06d0L119-R136) [[5]](diffhunk://#diff-e5e1e5e42fecc4ac6302da87724d37a7c9330d33ad2878c954f305bb771b06d0R183-R186) [[6]](diffhunk://#diff-578da9e8036be762a9de45468ee2cca899ff039141ac9e9ce26ac3d1c92dab56R150-R155) [[7]](diffhunk://#diff-578da9e8036be762a9de45468ee2cca899ff039141ac9e9ce26ac3d1c92dab56R171-R176) [[8]](diffhunk://#diff-e0ad572482f64a053e1d69295cfb1e7c2b0d704d62218543f56fb151474cdf85R587-R610)

**Reservation Validation Improvements:**

- Enhanced backend validation to prevent reservation of time slots that have already passed on the current day, both when selecting slots and when submitting reservations, for both regular and event reservations. [[1]](diffhunk://#diff-dd61698918b4bab82a333821fdbac8c9e2bc9d3d2954314d79d44f628233c5b4R137-R148) [[2]](diffhunk://#diff-dd61698918b4bab82a333821fdbac8c9e2bc9d3d2954314d79d44f628233c5b4R177-R183) [[3]](diffhunk://#diff-e0ad572482f64a053e1d69295cfb1e7c2b0d704d62218543f56fb151474cdf85R433-R444) [[4]](diffhunk://#diff-e0ad572482f64a053e1d69295cfb1e7c2b0d704d62218543f56fb151474cdf85R474-R479) [[5]](diffhunk://#diff-1a1e39f3907a7082b03bbfbe14d5e8386471c2b63d87921cee8fd0217d7de6e7R83-R84) [[6]](diffhunk://#diff-1a1e39f3907a7082b03bbfbe14d5e8386471c2b63d87921cee8fd0217d7de6e7R124-R128) [[7]](diffhunk://#diff-1a1e39f3907a7082b03bbfbe14d5e8386471c2b63d87921cee8fd0217d7de6e7R220-R222) [[8]](diffhunk://#diff-1a1e39f3907a7082b03bbfbe14d5e8386471c2b63d87921cee8fd0217d7de6e7R251-R259)

**Price Calculation Updates:**

- Updated reservation and mypage views and API responses to include option prices in the total price calculation, ensuring users see the correct total cost. [[1]](diffhunk://#diff-dd61698918b4bab82a333821fdbac8c9e2bc9d3d2954314d79d44f628233c5b4L65-R65) [[2]](diffhunk://#diff-439479170f0196e2f7ff588cdea81ba2e78a1102e410451158d02badfd0caa06L37-R37) [[3]](diffhunk://#diff-52b46b4a27227ec825b6ded62d15907988b6a145bbe2fe3ab8b043fcbfa47f4fL60-R63)

**UI/UX Enhancements:**

- Added "今日予約する" ("Book Today") buttons and navigation links throughout the site, including in the navigation bar, menu detail pages, and responsive menus, to highlight the new same-day reservation capability. [[1]](diffhunk://#diff-e5e1e5e42fecc4ac6302da87724d37a7c9330d33ad2878c954f305bb771b06d0R28-R32) [[2]](diffhunk://#diff-e5e1e5e42fecc4ac6302da87724d37a7c9330d33ad2878c954f305bb771b06d0L110-R115) [[3]](diffhunk://#diff-e5e1e5e42fecc4ac6302da87724d37a7c9330d33ad2878c954f305bb771b06d0L119-R136) [[4]](diffhunk://#diff-e5e1e5e42fecc4ac6302da87724d37a7c9330d33ad2878c954f305bb771b06d0R183-R186) [[5]](diffhunk://#diff-578da9e8036be762a9de45468ee2cca899ff039141ac9e9ce26ac3d1c92dab56R150-R155) [[6]](diffhunk://#diff-578da9e8036be762a9de45468ee2cca899ff039141ac9e9ce26ac3d1c92dab56R171-R176)
- Changed the label for today's date in the business hours list to "今日予約する" for clarity.

**Other Improvements:**

- Improved how available reservation dates are determined in the calendar view by ensuring only today and future dates are shown.
- Ensured that reservation option data is eagerly loaded where necessary to support the above features. [[1]](diffhunk://#diff-dd61698918b4bab82a333821fdbac8c9e2bc9d3d2954314d79d44f628233c5b4L37-R37) [[2]](diffhunk://#diff-b20b338f191f5548f89832584d6abd6a17c8ca4c20a7bd828b8ec959a814cd0bL23-R23)